### PR TITLE
Update chinese translations

### DIFF
--- a/modinfo.lua
+++ b/modinfo.lua
@@ -542,11 +542,11 @@ local english = {
 		OPTIONS = {
 			["false"] = {
 				DESCRIPTION = "No",
-				HOVER = "Markers are shown."
+				HOVER = "Markers are not shown."
 			},
 			["true"] = {
 				DESCRIPTION = "Yes",
-				HOVER = "Markers are not shown."
+				HOVER = "Markers are shown."
 			},
 		},
 	},
@@ -1828,16 +1828,16 @@ local chinese = {
 		}
 	},
 	klaus_sack_markers = {
-		LABEL = "Loot Stash Markers (Server Only)",
-		HOVER = "Whether Loot Stash spawning locations are marked. *Only the server's choice matters.*",
+		LABEL = "克劳斯袋子标记 (服务器选项)",
+		HOVER = "是否标记克劳斯袋子的位置 *该选项仅服务器有效*",
 		OPTIONS = {
 			["false"] = {
-				DESCRIPTION = "No",
-				HOVER = "Markers are shown."
+				DESCRIPTION = "否",
+				HOVER = "不显示标记"
 			},
 			["true"] = {
-				DESCRIPTION = "Yes",
-				HOVER = "Markers are not shown."
+				DESCRIPTION = "是",
+				HOVER = "显示标记"
 			},
 		},
 	},

--- a/modinfo.lua
+++ b/modinfo.lua
@@ -17,7 +17,6 @@ LICENSE in the form of a LICENSE file in the root of the source
 directory. If not, please refer to
 <https://raw.githubusercontent.com/Recex/Licenses/master/SharedSourceLicense/LICENSE.txt>
 ]]
-
 ---------------------------------------
 -- Mod information for the game to process.
 -- @script modinfo
@@ -38,13 +37,12 @@ priority = -10000 --[[ rezecib's Geometric Placement has -10, chinese++, has -99
 ideally, we come last in the mod loading order to make life easier. 
 that way, I can try to be compatible with other mods without them having to worry about compatibility with Insight. after all, probably better if I handle it.
 --]]
-
 -- DS
 api_version = 6
 dont_starve_compatible = true
 reign_of_giants_compatible = true -- DLC0001
 shipwrecked_compatible = true -- DLC0002
-hamlet_compatible = true -- DLC0003 
+hamlet_compatible = true -- DLC0003
 
 -- DST
 api_version_dst = 10
@@ -75,24 +73,18 @@ server_filter_tags = {"insight_" .. version}
 	end
 
 ]]
-
-
 local translations = {}
 local english = {
-
 	-- description
 	ds_not_enabled = "Mod must be enabled for functioning modinfo",
 	update_info = "Added lureplant inventory information, added pink highlighting, Loot Stash locations, battlesong information, performance optimization, saddle information, added orange highlighting, finiteuses max uses on inspection.",
 	update_info_ds = "performance increase, bug fixes",
 	crashreporter_info = "**Crash reporter added**, you should enable it in the client & server config",
-
 	mod_explanation = "Basically Show Me but with more features.",
 	config_paths = "Server Configuration: Main Menu -> Host Game -> Mods -> Server Mods -> Insight -> Configure Mod\n-------------------------\nClient Configuration: Main Menu -> Mods -> Server Mods -> Insight -> Configure Mod",
-
 	config_disclaimer = "Make sure to check out the configuration options.",
 	version = "Version",
 	latest_update = "Latest update",
-
 	-- section titles
 	sectiontitle_formatting = "Formatting",
 	sectiontitle_indicators = "Indicators",
@@ -100,11 +92,9 @@ local english = {
 	sectiontitle_informationcontrol = "Information Control",
 	sectiontitle_miscellaneous = "Miscellaneous",
 	sectiontitle_debugging = "Debugging",
-
 	-- etc
 	undefined = "Undefined",
 	undefined_description = "Defaults to: ",
-
 	-- Formatting
 	language = {
 		--------------------------------------------------------------------------
@@ -124,22 +114,22 @@ local english = {
 			["zh"] = {
 				DESCRIPTION = "Chinese",
 				HOVER = "Chinese"
-			},
-		},
+			}
+		}
 	},
 	info_style = {
 		LABEL = "Icon Mode",
 		HOVER = "Whether you want to use icons or text.",
 		OPTIONS = {
 			["text"] = {
-				DESCRIPTION = "No",
+				DESCRIPTION = "Text",
 				HOVER = "Text will be used"
 			},
 			["icon"] = {
-				DESCRIPTION = "Yes",
+				DESCRIPTION = "Icon",
 				HOVER = "Icons will be used over text where possible."
-			},
-		},
+			}
+		}
 	},
 	text_coloring = {
 		LABEL = "Text Coloring",
@@ -152,8 +142,8 @@ local english = {
 			["true"] = {
 				DESCRIPTION = "Enabled",
 				HOVER = "Text coloring will be used."
-			},
-		},
+			}
+		}
 	},
 	alt_only_information = {
 		LABEL = "Inspect Only",
@@ -166,8 +156,8 @@ local english = {
 			["true"] = {
 				DESCRIPTION = "Enabled",
 				HOVER = "Information only displays on inspection."
-			},
-		},
+			}
+		}
 	},
 	--[[
 	alt_only_is_verbose = {
@@ -200,8 +190,8 @@ local english = {
 			["2"] = {
 				DESCRIPTION = "Percentages",
 				HOVER = "Will provide use default percentages on item slots."
-			},
-		},
+			}
+		}
 	},
 	time_style = {
 		LABEL = "Time style",
@@ -230,12 +220,12 @@ local english = {
 			["both_short"] = {
 				DESCRIPTION = "Both (Short)",
 				HOVER = "Use both time styles and shorten: x.y days (hours:minutes:seconds)."
-			},
-		},
+			}
+		}
 	},
 	highlighting = {
 		LABEL = "Highlighting",
-		HOVER = "Whether item highlighting is enabled. (\"Finder\")",
+		HOVER = 'Whether item highlighting is enabled. ("Finder")',
 		OPTIONS = {
 			["false"] = {
 				DESCRIPTION = "No",
@@ -244,8 +234,8 @@ local english = {
 			["true"] = {
 				DESCRIPTION = "Yes",
 				HOVER = "Chests/items will be highlighted."
-			},
-		},
+			}
+		}
 	},
 	highlighting_color = {
 		LABEL = "Highlighting Color",
@@ -253,15 +243,15 @@ local english = {
 		OPTIONS = {
 			["RED"] = {
 				DESCRIPTION = "Red",
-				HOVER = "Red",
+				HOVER = "Red"
 			},
 			["GREEN"] = {
 				DESCRIPTION = "Green",
-				HOVER = "Green",
+				HOVER = "Green"
 			},
 			["BLUE"] = {
 				DESCRIPTION = "Blue",
-				HOVER = "Blue",
+				HOVER = "Blue"
 			},
 			["LIGHT_BLUE"] = {
 				DESCRIPTION = "Light Blue",
@@ -269,11 +259,11 @@ local english = {
 			},
 			["PURPLE"] = {
 				DESCRIPTION = "Purple",
-				HOVER = "Purple",
+				HOVER = "Purple"
 			},
 			["YELLOW"] = {
 				DESCRIPTION = "Yellow",
-				HOVER = "Yellow",
+				HOVER = "Yellow"
 			},
 			["WHITE"] = {
 				DESCRIPTION = "White",
@@ -300,8 +290,8 @@ local english = {
 			["true"] = {
 				DESCRIPTION = "Yes",
 				HOVER = "Fuel entities will be highlighted."
-			},
-		},
+			}
+		}
 	},
 	fuel_highlighting_color = {
 		LABEL = "Fuel Highlighting Color",
@@ -309,15 +299,15 @@ local english = {
 		OPTIONS = {
 			["RED"] = {
 				DESCRIPTION = "Red",
-				HOVER = "Red",
+				HOVER = "Red"
 			},
 			["GREEN"] = {
 				DESCRIPTION = "Green",
-				HOVER = "Green",
+				HOVER = "Green"
 			},
 			["BLUE"] = {
 				DESCRIPTION = "Blue",
-				HOVER = "Blue",
+				HOVER = "Blue"
 			},
 			["LIGHT_BLUE"] = {
 				DESCRIPTION = "Light Blue",
@@ -325,11 +315,11 @@ local english = {
 			},
 			["PURPLE"] = {
 				DESCRIPTION = "Purple",
-				HOVER = "Purple",
+				HOVER = "Purple"
 			},
 			["YELLOW"] = {
 				DESCRIPTION = "Yellow",
-				HOVER = "Yellow",
+				HOVER = "Yellow"
 			},
 			["WHITE"] = {
 				DESCRIPTION = "White",
@@ -359,8 +349,8 @@ local english = {
 			["true"] = {
 				DESCRIPTION = "Yes",
 				HOVER = "Attack ranges are shown."
-			},
-		},
+			}
+		}
 	},
 	attack_range_type = {
 		LABEL = "Attack Range Type",
@@ -377,8 +367,8 @@ local english = {
 			["both"] = {
 				DESCRIPTION = "Both",
 				HOVER = "Both hit and attack range are shown."
-			},
-		},
+			}
+		}
 	},
 	hover_range_indicator = {
 		LABEL = "Item Range Hover",
@@ -391,8 +381,8 @@ local english = {
 			["true"] = {
 				DESCRIPTION = "Yes",
 				HOVER = "Range is shown."
-			},
-		},
+			}
+		}
 	},
 	boss_indicator = {
 		LABEL = "Boss Indicator",
@@ -405,8 +395,8 @@ local english = {
 			["true"] = {
 				DESCRIPTION = "Yes",
 				HOVER = "Boss indicators are shown."
-			},
-		},
+			}
+		}
 	},
 	notable_indicator = {
 		LABEL = "Notable Indicator",
@@ -419,8 +409,8 @@ local english = {
 			["true"] = {
 				DESCRIPTION = "Yes",
 				HOVER = "Notable indicators are shown."
-			},
-		},
+			}
+		}
 	},
 	pipspook_indicator = {
 		LABEL = "Pipspook toy indicators",
@@ -433,8 +423,8 @@ local english = {
 			["true"] = {
 				DESCRIPTION = "Yes",
 				HOVER = "Pipspook toy indicators are shown."
-			},
-		},
+			}
+		}
 	},
 	bottle_indicator = {
 		LABEL = "Bottle Indicator",
@@ -447,8 +437,8 @@ local english = {
 			["true"] = {
 				DESCRIPTION = "Yes",
 				HOVER = "Message indicators are shown."
-			},
-		},
+			}
+		}
 	},
 	hunt_indicator = {
 		LABEL = "Hunt Indicator",
@@ -461,8 +451,8 @@ local english = {
 			["true"] = {
 				DESCRIPTION = "Yes",
 				HOVER = "Hunt indicators are shown."
-			},
-		},
+			}
+		}
 	},
 	orchestrina_indicator = {
 		LABEL = "Archive Puzzle Helper",
@@ -493,8 +483,8 @@ local english = {
 			["2"] = {
 				DESCRIPTION = "Always",
 				HOVER = "Always show lightning rod range."
-			},
-		},
+			}
+		}
 	},
 	blink_range = {
 		LABEL = "Blink range",
@@ -507,8 +497,8 @@ local english = {
 			["true"] = {
 				DESCRIPTION = "Yes",
 				HOVER = "Blink range shown."
-			},
-		},
+			}
+		}
 	},
 	wortox_soul_range = {
 		LABEL = "Wortox Soul range",
@@ -521,8 +511,8 @@ local english = {
 			["true"] = {
 				DESCRIPTION = "Yes",
 				HOVER = "Soul pickup ranges shown."
-			},
-		},
+			}
+		}
 	},
 	battlesong_range = {
 		LABEL = "Battle song range",
@@ -543,8 +533,8 @@ local english = {
 			["both"] = {
 				DESCRIPTION = "Both",
 				HOVER = "Both ranges are shown."
-			},
-		},
+			}
+		}
 	},
 	klaus_sack_markers = {
 		LABEL = "Loot Stash Markers (Server Only)",
@@ -575,8 +565,8 @@ local english = {
 			["2"] = {
 				DESCRIPTION = "Sinkholes & Map",
 				HOVER = "Apply to both map icons & sinkholes."
-			},
-		},
+			}
+		}
 	},
 	--------------------------------------------------------------------------
 	--[[ Food Related ]]
@@ -587,17 +577,17 @@ local english = {
 		OPTIONS = {
 			["false"] = {
 				DESCRIPTION = "No",
-				HOVER = "Food information is not shown.",
+				HOVER = "Food information is not shown."
 			},
 			["true"] = {
 				DESCRIPTION = "Yes",
 				HOVER = "Food information is shown."
-			},
-		},
+			}
+		}
 	},
 	food_style = {
 		LABEL = "Food style",
-		HOVER = "Food information length.",
+		HOVER = "How Food information is displayed.",
 		OPTIONS = {
 			["short"] = {
 				DESCRIPTION = "Short",
@@ -606,8 +596,8 @@ local english = {
 			["long"] = {
 				DESCRIPTION = "Long",
 				HOVER = "Hunger: +X / Sanity: -X / Health: +X"
-			},
-		},
+			}
+		}
 	},
 	food_order = {
 		LABEL = "Food order",
@@ -620,8 +610,8 @@ local english = {
 			["wiki"] = {
 				DESCRIPTION = "Wiki",
 				HOVER = "Health / Hunger / Sanity"
-			},
-		},
+			}
+		}
 	},
 	food_units = {
 		LABEL = "Display food units",
@@ -629,13 +619,13 @@ local english = {
 		OPTIONS = {
 			["false"] = {
 				DESCRIPTION = "No",
-				HOVER = "Food units will NOT be displayed."
+				HOVER = "Food units will not be displayed."
 			},
 			["true"] = {
 				DESCRIPTION = "Yes",
 				HOVER = "Food units WILL be displayed."
-			},
-		},
+			}
+		}
 	},
 	food_effects = {
 		LABEL = "Food Effects",
@@ -648,8 +638,8 @@ local english = {
 			["true"] = {
 				DESCRIPTION = "Yes",
 				HOVER = "Special food effects will show."
-			},
-		},
+			}
+		}
 	},
 	stewer_chef = {
 		LABEL = "Chef Identifiers",
@@ -662,8 +652,8 @@ local english = {
 			["true"] = {
 				DESCRIPTION = "Yes",
 				HOVER = "The chef will be shown."
-			},
-		},
+			}
+		}
 	},
 	food_memory = {
 		LABEL = "Food Memory",
@@ -676,8 +666,8 @@ local english = {
 			["true"] = {
 				DESCRIPTION = "Yes",
 				HOVER = "Your food memory will be shown."
-			},
-		},
+			}
+		}
 	},
 	display_perishable = {
 		LABEL = "Perishing",
@@ -690,8 +680,8 @@ local english = {
 			["true"] = {
 				DESCRIPTION = "Yes",
 				HOVER = "Perishable information is shown."
-			},
-		},
+			}
+		}
 	},
 	--------------------------------------------------------------------------
 	--[[ Information Control ]]
@@ -702,13 +692,13 @@ local english = {
 		OPTIONS = {
 			["false"] = {
 				DESCRIPTION = "No",
-				HOVER = "The pageant winners are not shown.",
+				HOVER = "The pageant winners are not shown."
 			},
 			["true"] = {
 				DESCRIPTION = "Yes",
 				HOVER = "The pageant winners  are shown."
-			},
-		},
+			}
+		}
 	},
 	display_yotb_appraisal = {
 		LABEL = "Appraisal Values [YOTB]",
@@ -716,13 +706,13 @@ local english = {
 		OPTIONS = {
 			["false"] = {
 				DESCRIPTION = "No",
-				HOVER = "The appraisal values are not shown.",
+				HOVER = "The appraisal values are not shown."
 			},
 			["true"] = {
 				DESCRIPTION = "Yes",
 				HOVER = "The appraisal values are shown."
-			},
-		},
+			}
+		}
 	},
 	display_shared_stats = {
 		LABEL = "Playerlist Stats",
@@ -730,13 +720,13 @@ local english = {
 		OPTIONS = {
 			["false"] = {
 				DESCRIPTION = "No",
-				HOVER = "The stats are not shown.",
+				HOVER = "The stats are not shown."
 			},
 			["true"] = {
 				DESCRIPTION = "Yes",
 				HOVER = "The stats are shown."
-			},
-		},
+			}
+		}
 	},
 	display_fishing_information = {
 		LABEL = "Fishing information",
@@ -744,13 +734,13 @@ local english = {
 		OPTIONS = {
 			["false"] = {
 				DESCRIPTION = "No",
-				HOVER = "Fishing information is not shown.",
+				HOVER = "Fishing information is not shown."
 			},
 			["true"] = {
 				DESCRIPTION = "Yes",
 				HOVER = "Fishing information is shown."
-			},
-		},
+			}
+		}
 	},
 	display_spawner_information = {
 		LABEL = "Spawner information",
@@ -758,13 +748,13 @@ local english = {
 		OPTIONS = {
 			["false"] = {
 				DESCRIPTION = "No",
-				HOVER = "The spawner information is not shown.",
+				HOVER = "The spawner information is not shown."
 			},
 			["true"] = {
 				DESCRIPTION = "Yes",
 				HOVER = "The spawner information is shown."
-			},
-		},
+			}
+		}
 	},
 	weapon_damage = {
 		LABEL = "Weapon Damage",
@@ -772,13 +762,13 @@ local english = {
 		OPTIONS = {
 			["false"] = {
 				DESCRIPTION = "No",
-				HOVER = "Weapon damage is not shown.",
+				HOVER = "Weapon damage is not shown."
 			},
 			["true"] = {
 				DESCRIPTION = "Yes",
 				HOVER = "Weapon damage is shown."
-			},
-		},
+			}
+		}
 	},
 	repair_values = {
 		LABEL = "Repair Values",
@@ -786,12 +776,12 @@ local english = {
 		OPTIONS = {
 			["false"] = {
 				DESCRIPTION = "No",
-				HOVER = "Repair information is not shown.",
+				HOVER = "Repair information is not shown."
 			},
 			["true"] = {
 				DESCRIPTION = "Yes",
-				HOVER = "Repair information is shown.",
-			},
+				HOVER = "Repair information is shown."
+			}
 		}
 	},
 	soil_moisture = {
@@ -800,23 +790,23 @@ local english = {
 		OPTIONS = {
 			["0"] = {
 				DESCRIPTION = "Off",
-				HOVER = "Soil moisture is not shown.",
+				HOVER = "Soil moisture is not shown."
 			},
 			["1"] = {
 				DESCRIPTION = "Soil",
-				HOVER = "Only soil moisture is shown.",
+				HOVER = "Only soil moisture is shown."
 			},
 			["2"] = {
 				DESCRIPTION = "Soil / Plant",
-				HOVER = "Soil moisture and the plant consumption rate is shown.",
+				HOVER = "Soil moisture and the plant consumption rate is shown."
 			},
 			["3"] = {
 				DESCRIPTION = "Soil, Plant, Tile",
-				HOVER = "Soil moisture, plant consumption, and the tile moisture rate is shown.",
+				HOVER = "Soil moisture, plant consumption, and the tile moisture rate is shown."
 			},
 			["4"] = {
 				DESCRIPTION = "All",
-				HOVER = "Soil moisture, plant consumption, and the **NET** tile moisture rate is shown.",
+				HOVER = "Soil moisture, plant consumption, and the **NET** tile moisture rate is shown."
 			}
 		}
 	},
@@ -826,20 +816,20 @@ local english = {
 		OPTIONS = {
 			["0"] = {
 				DESCRIPTION = "Off",
-				HOVER = "Soil nutrients are not shown.",
+				HOVER = "Soil nutrients are not shown."
 			},
 			["1"] = {
 				DESCRIPTION = "Soil",
-				HOVER = "Only soil nutrients are shown.",
+				HOVER = "Only soil nutrients are shown."
 			},
 			["2"] = {
 				DESCRIPTION = "Soil / Plant",
-				HOVER = "Soil nutrients and the plant consumption rate are shown.",
+				HOVER = "Soil nutrients and the plant consumption rate are shown."
 			},
 			["3"] = {
 				DESCRIPTION = "Soil, Plant, Tile",
-				HOVER = "Soil nutrients, plant consumption, and the tile nutrients rate are all shown.",
-			},
+				HOVER = "Soil nutrients, plant consumption, and the tile nutrients rate are all shown."
+			}
 			--[[
 			["4"] = {
 				DESCRIPTION = "All",
@@ -854,11 +844,11 @@ local english = {
 		OPTIONS = {
 			["0"] = {
 				DESCRIPTION = "No",
-				HOVER = "Plant stress is not shown.",
+				HOVER = "Plant stress is not shown."
 			},
 			["1"] = {
 				DESCRIPTION = "With Hat",
-				HOVER = "Plant stress will be shown if you have the Premier Gardeneer Hat.",
+				HOVER = "Plant stress will be shown if you have the Premier Gardeneer Hat."
 			},
 			["2"] = {
 				DESCRIPTION = "Always",
@@ -866,19 +856,18 @@ local english = {
 			}
 		}
 	},
-	
 	display_weighable = {
 		LABEL = "Item Weight",
 		HOVER = "Determines whether item weight is shown.",
 		OPTIONS = {
 			["false"] = {
 				DESCRIPTION = "No",
-				HOVER = "Item weight is not shown.",
+				HOVER = "Item weight is not shown."
 			},
 			["true"] = {
 				DESCRIPTION = "Yes",
-				HOVER = "Item weight is shown.",
-			},
+				HOVER = "Item weight is shown."
+			}
 		}
 	},
 	display_world_events = {
@@ -892,8 +881,8 @@ local english = {
 			["true"] = {
 				DESCRIPTION = "Yes",
 				HOVER = "World data is shown."
-			},
-		},
+			}
+		}
 	},
 	display_weather = {
 		LABEL = "Show weather information",
@@ -906,8 +895,8 @@ local english = {
 			["true"] = {
 				DESCRIPTION = "Yes",
 				HOVER = "Weather is shown."
-			},
-		},
+			}
+		}
 	},
 	nightmareclock_display = {
 		LABEL = "Nightmare Phases",
@@ -924,8 +913,8 @@ local english = {
 			["2"] = {
 				DESCRIPTION = "On",
 				HOVER = "Nightmare phase information is always shown."
-			},
-		},
+			}
+		}
 	},
 	display_health = {
 		LABEL = "Health",
@@ -938,8 +927,8 @@ local english = {
 			["true"] = {
 				DESCRIPTION = "Yes",
 				HOVER = "Health information is shown."
-			},
-		},
+			}
+		}
 	},
 	display_mob_attack_damage = {
 		LABEL = "Mob Attack Damage",
@@ -947,13 +936,13 @@ local english = {
 		OPTIONS = {
 			["false"] = {
 				DESCRIPTION = "No",
-				HOVER = "Mob attack damage is not shown.",
+				HOVER = "Mob attack damage is not shown."
 			},
 			["true"] = {
 				DESCRIPTION = "Yes",
-				HOVER = "Mob attack damage is shown.",
-			},
-		},
+				HOVER = "Mob attack damage is shown."
+			}
+		}
 	},
 	growth_verbosity = {
 		LABEL = "Growth Verbosity",
@@ -970,8 +959,8 @@ local english = {
 			["2"] = {
 				DESCRIPTION = "All",
 				HOVER = "Displays current stage name, number of stages, and time until next stage."
-			},
-		},
+			}
+		}
 	},
 	display_finiteuses = {
 		LABEL = "Tool Durability",
@@ -984,8 +973,8 @@ local english = {
 			["true"] = {
 				DESCRIPTION = "Yes",
 				HOVER = "Tool durability will be displayed."
-			},
-		},
+			}
+		}
 	},
 	display_timers = {
 		LABEL = "Timers",
@@ -998,8 +987,8 @@ local english = {
 			["true"] = {
 				DESCRIPTION = "Yes",
 				HOVER = "Timers will be displayed."
-			},
-		},
+			}
+		}
 	},
 	display_upgradeable = {
 		LABEL = "Upgradeables",
@@ -1012,8 +1001,8 @@ local english = {
 			["true"] = {
 				DESCRIPTION = "Yes",
 				HOVER = "Displays information for upgradeable structures, such as spider dens."
-			},
-		},
+			}
+		}
 	},
 	naughtiness_verbosity = {
 		LABEL = "Naughtiness verbosity",
@@ -1030,8 +1019,8 @@ local english = {
 			["2"] = {
 				DESCRIPTION = "Plr/Creature",
 				HOVER = "Player and creature naughtiness values will display."
-			},
-		},
+			}
+		}
 	},
 	follower_info = {
 		LABEL = "Follower information",
@@ -1044,8 +1033,8 @@ local english = {
 			["true"] = {
 				DESCRIPTION = "Enabled",
 				HOVER = "Will display follower information."
-			},
-		},
+			}
+		}
 	},
 	herd_information = {
 		LABEL = "Herd information",
@@ -1058,8 +1047,8 @@ local english = {
 			["true"] = {
 				DESCRIPTION = "Enabled",
 				HOVER = "Will display herd information."
-			},
-		},
+			}
+		}
 	},
 	domestication_information = {
 		LABEL = "Domestication info",
@@ -1072,8 +1061,8 @@ local english = {
 			["true"] = {
 				DESCRIPTION = "Enabled",
 				HOVER = "Will display domestication information."
-			},
-		},
+			}
+		}
 	},
 	display_pollination = {
 		LABEL = "Pollination",
@@ -1086,8 +1075,8 @@ local english = {
 			["true"] = {
 				DESCRIPTION = "Enabled",
 				HOVER = "Will display pollination information."
-			},
-		},
+			}
+		}
 	},
 	display_hunger = {
 		LABEL = "Hunger",
@@ -1104,8 +1093,8 @@ local english = {
 			["2"] = {
 				DESCRIPTION = "All",
 				HOVER = "Will display all hunger information."
-			},
-		},
+			}
+		}
 	},
 	display_sanityaura = {
 		LABEL = "Sanity Auras",
@@ -1118,8 +1107,8 @@ local english = {
 			["true"] = {
 				DESCRIPTION = "Enabled",
 				HOVER = "Will display sanity auras."
-			},
-		},
+			}
+		}
 	},
 	item_worth = {
 		LABEL = "Display item worth",
@@ -1132,8 +1121,8 @@ local english = {
 			["true"] = {
 				DESCRIPTION = "Yes",
 				HOVER = "Will display gold and dubloon value."
-			},
-		},
+			}
+		}
 	},
 	appeasement_value = {
 		LABEL = "Display Appeasement",
@@ -1146,12 +1135,12 @@ local english = {
 			["true"] = {
 				DESCRIPTION = "Yes",
 				HOVER = "Will display appeasement value."
-			},
-		},
+			}
+		}
 	},
 	fuel_verbosity = {
 		LABEL = "Fuel Verbosity",
-		HOVER = "How verbose fuel information is.",
+		HOVER = "How verbose fuel information is displayed.",
 		OPTIONS = {
 			["0"] = {
 				DESCRIPTION = "None",
@@ -1162,10 +1151,10 @@ local english = {
 				HOVER = "Standard fuel information will show."
 			},
 			["2"] = {
-				DESCRIPTION = "Maximum",
+				DESCRIPTION = "All",
 				HOVER = "All fuel information will show."
-			},
-		},
+			}
+		}
 	},
 	--------------------------------------------------------------------------
 	--[[ Miscellaneous ]]
@@ -1214,7 +1203,7 @@ local english = {
 	},
 	unrandomizer = {
 		LABEL = "Unrandomizer",
-		HOVER = "[Server Only] \"Solves\" the randomness of some situations.",
+		HOVER = '[Server Only] "Solves" the randomness of some situations.',
 		OPTIONS = {
 			["false"] = {
 				DESCRIPTION = "No",
@@ -1237,26 +1226,26 @@ local english = {
 			["true"] = {
 				DESCRIPTION = "Yes",
 				HOVER = "Combat popups (ie damage) will account for any buffs/nerfs your character has."
-			},
-		},
+			}
+		}
 	},
 	info_preload = {
 		LABEL = "Information preloading",
-		HOVER = "Whether information is preloaded when entities become visible. Trades network usage for faster performance. Recommended to use \"All\".",
+		HOVER = 'Whether information is preloaded when entities become visible. Trades network usage for faster performance. Recommended to use "All".',
 		OPTIONS = {
 			["0"] = {
 				DESCRIPTION = "No",
-				HOVER = "SEVERE FPS DROP! NOT RECOMMENDED!" -- most severe fps drop
+				HOVER = "Severe FPS drop, not recommended." -- most severe fps drop
 			},
 			["1"] = {
 				DESCRIPTION = "Containers",
-				HOVER = "POSSIBLE FPS DROP. NOT RECOMMENDED. CAN USE FOR SMALL, CLEAN BASES."
+				HOVER = "Possible FPS drop, not recommended. Can use for small, clean bases."
 			},
 			["2"] = {
 				DESCRIPTION = "All",
-				HOVER = "FASTEST. RECOMMENDED."
-			},
-		},
+				HOVER = "Highest FPS, recommended."
+			}
+		}
 	},
 	refresh_delay = {
 		LABEL = "Refresh delay",
@@ -1267,7 +1256,7 @@ local english = {
 				HOVER = "Dynamic updates based on players and performance."
 			},
 			["0"] = {
-				DESCRIPTION = "None",
+				DESCRIPTION = "Live",
 				HOVER = "Information is live."
 			},
 			["0_25"] = {
@@ -1285,8 +1274,8 @@ local english = {
 			["3"] = {
 				DESCRIPTION = "3s",
 				HOVER = "Information updates every 3 seconds."
-			},
-		},
+			}
+		}
 	},
 	--------------------------------------------------------------------------
 	--[[ Debugging ]]
@@ -1302,8 +1291,8 @@ local english = {
 			["true"] = {
 				DESCRIPTION = "Yes",
 				HOVER = "The log reporting is enabled."
-			},
-		},
+			}
+		}
 	},
 	crash_reporter = {
 		LABEL = "Crash Reporter",
@@ -1316,8 +1305,8 @@ local english = {
 			["true"] = {
 				DESCRIPTION = "Yes",
 				HOVER = "The crash reporter is enabled."
-			},
-		},
+			}
+		}
 	},
 	DEBUG_SHOW_NOTIMPLEMENTED = {
 		LABEL = "DEBUG_SHOW_NOTIMPLEMENTED",
@@ -1330,8 +1319,8 @@ local english = {
 			["true"] = {
 				DESCRIPTION = "Yes",
 				HOVER = "Will warn you if there are any components not accounted for."
-			},
-		},
+			}
+		}
 	},
 	DEBUG_SHOW_DISABLED = {
 		LABEL = "DEBUG_SHOW_DISABLED",
@@ -1344,8 +1333,8 @@ local english = {
 			["true"] = {
 				DESCRIPTION = "Yes",
 				HOVER = "Will display information for disabled descriptors."
-			},
-		},
+			}
+		}
 	},
 	DEBUG_SHOW_PREFAB = {
 		LABEL = "DEBUG_SHOW_PREFAB",
@@ -1358,8 +1347,8 @@ local english = {
 			["true"] = {
 				DESCRIPTION = "Yes",
 				HOVER = "Will display prefabs on entity."
-			},
-		},
+			}
+		}
 	},
 	DEBUG_ENABLED = {
 		LABEL = "DEBUG_ENABLED",
@@ -1372,9 +1361,9 @@ local english = {
 			["true"] = {
 				DESCRIPTION = "Yes",
 				HOVER = "Insight will show debugging information."
-			},
-		},
-	},
+			}
+		}
+	}
 }
 translations["en"] = english
 
@@ -1382,14 +1371,11 @@ local chinese = {
 	-- description
 	update_info = "",
 	crashreporter_info = "**添加了崩溃报告器**, 你可以在客户端或服务器设置界面来开启它。",
-
 	mod_explanation = "以 Show Me 为基础，但功能更全面",
 	config_paths = "服务器设置方法: 主界面 -> 创建世界-> 模组 -> 服务器模组 -> Insight -> 模组设置\n-------------------------\n客户端设置方法: 主界面 -> 模组 -> 服务器模组 -> Insight -> 模组设置",
-
 	config_disclaimer = "请确认你设置的各个选项, 尤其是设置好显示的和设置不再显示的信息，需要格外注意。",
 	version = "版本",
 	latest_update = "最新更新",
-
 	-- section titles
 	sectiontitle_formatting = "格式",
 	sectiontitle_indicators = "指示器",
@@ -1397,11 +1383,9 @@ local chinese = {
 	sectiontitle_informationcontrol = "信息控制",
 	sectiontitle_miscellaneous = "杂项",
 	sectiontitle_debugging = "调试",
-
 	-- etc
 	undefined = "默认",
 	undefined_description = "默认为：",
-
 	-- Formatting
 	language = {
 		--------------------------------------------------------------------------
@@ -1421,208 +1405,224 @@ local chinese = {
 			["zh"] = {
 				DESCRIPTION = "中文",
 				HOVER = "中文"
-			},
-		},
+			}
+		}
 	},
 	info_style = {
-		LABEL = "信息类型",
-		HOVER = "选择图标模式还是文字模式。",
+		LABEL = "图标模式",
+		HOVER = "是否显示图标或文字",
 		OPTIONS = {
 			["text"] = {
-				DESCRIPTION = "否",
-				HOVER = "文字模式"
+				DESCRIPTION = "文字",
+				HOVER = "显示纯文字"
 			},
 			["icon"] = {
-				DESCRIPTION = "是",
-				HOVER = "图标会替代文字来显示。"
-			},
-		},
+				DESCRIPTION = "图标",
+				HOVER = "显示图标替代文字"
+			}
+		}
 	},
 	text_coloring = {
-		LABEL = "文字的颜色",
+		LABEL = "文字着色",
 		HOVER = "是否启用文字着色。",
 		OPTIONS = {
 			["false"] = {
 				DESCRIPTION = "禁用",
-				HOVER = "文字着色功能将被禁用。 :("
+				HOVER = "禁用文字着色 :("
 			},
 			["true"] = {
 				DESCRIPTION = "启用",
-				HOVER = "文字着色功能将被启用。"
-			},
-		},
+				HOVER = "启用文字着色"
+			}
+		}
 	},
 	alt_only_information = {
-		LABEL = "仅检查",
-		HOVER = "是否仅当按住Alt键时显示信息。",
+		LABEL = "仅在检查时显示",
+		HOVER = "是否仅当按住 Alt 键时显示信息",
 		OPTIONS = {
 			["false"] = {
-				DESCRIPTION = "关闭",
-				HOVER = "信息将正常显示。"
+				DESCRIPTION = "禁用",
+				HOVER = "信息正常显示"
 			},
 			["true"] = {
-				DESCRIPTION = "开启",
-				HOVER = "仅当按住Alt键时显示信息。"
+				DESCRIPTION = "启用",
+				HOVER = "仅当按住 Alt 键时显示信息"
+			}
+		}
+	},
+	--[[
+	alt_only_is_verbose = {
+		LABEL = "仅在检查时显示的内容",
+		HOVER = "*只有 \"仅在检查时显示\" 启用时有效。*\n按住 Alt 键时显示标准或扩展信息。",
+		OPTIONS = {
+			["false"] = {
+				DESCRIPTION = "标准",
+				HOVER = "显示标准信息。"
+			},
+			["true"] = {
+				DESCRIPTION = "扩展",
+				HOVER = "显示扩展信息。"
 			},
 		},
 	},
+	--]]
 	itemtile_display = {
-		LABEL = "物品格子信息",
-		HOVER = "也就是显示信息的种类而不是以百分比的形式显示。",
+		LABEL = "库存物品栏信息",
+		HOVER = "物品栏信息显示的类型",
 		OPTIONS = {
 			["0"] = {
 				DESCRIPTION = "无",
-				HOVER = "物品将不会显示任何信息。"
+				HOVER = "不显示任何信息"
 			},
 			["1"] = {
-				DESCRIPTION = "数字型",
-				HOVER = "在物品格子里显示数字。"
+				DESCRIPTION = "数字",
+				HOVER = "显示具体次数"
 			},
 			["2"] = {
-				DESCRIPTION = "百分比型",
-				HOVER = "在物品格子里显示百分比。"
-			},
-		},
+				DESCRIPTION = "百分比",
+				HOVER = "显示默认百分比"
+			}
+		}
 	},
 	time_style = {
-		LABEL = "时间风格",
-		HOVER = "如何显示时间信息。",
+		LABEL = "时间样式",
+		HOVER = "如何显示时间信息",
 		OPTIONS = {
 			["gametime"] = {
 				DESCRIPTION = "游戏时间",
-				HOVER = "以游戏内时间为基础显示时间信息：天数，时间小段。"
+				HOVER = "以游戏内时间为基础显示时间信息：天数，时间小段"
 			},
 			["realtime"] = {
 				DESCRIPTION = "现实时间",
-				HOVER = "以现实时间为基础现实时间信息：时，分，秒。"
+				HOVER = "以现实时间为基础现实时间信息：时，分，秒"
 			},
 			["both"] = {
 				DESCRIPTION = "兼用两种模式",
 				HOVER = "使用两种显示形式：天，时间小段（时，分，秒）"
 			},
 			["gametime_short"] = {
-				DESCRIPTION = "游戏时间（精简模式）",
-				HOVER = "简化版的以游戏内时间为基础显示时间信息。"
+				DESCRIPTION = "游戏时间（精简）",
+				HOVER = "简化版的以游戏内时间为基础显示时间信息"
 			},
 			["realtime_short"] = {
-				DESCRIPTION = "现实时间（精简模式）",
-				HOVER = "简化版的以现实时间为基础显示时间信息。"
+				DESCRIPTION = "现实时间（精简）",
+				HOVER = "简化版的以现实时间为基础显示时间信息"
 			},
 			["both_short"] = {
-				DESCRIPTION = "兼用两种模式（简化版）",
-				HOVER = "简化版的双模式显示。"
-			},
-		},
+				DESCRIPTION = "兼用两种模式（精简）",
+				HOVER = "简化版的双模式显示"
+			}
+		}
 	},
 	highlighting = {
-		LABEL = "启用高亮显示模式",
-		HOVER = "物品高亮模式是否开启。 (\"物品查找器\")",
+		LABEL = "高亮显示",
+		HOVER = '是否启用箱子/物品的高亮显示 ("物品查找器")',
 		OPTIONS = {
 			["false"] = {
 				DESCRIPTION = "否",
-				HOVER = "物品不会触发箱子智能查找，不会高亮显示。"
+				HOVER = "箱子/物品不会高亮显示"
 			},
 			["true"] = {
 				DESCRIPTION = "是",
-				HOVER = "智能高亮开启，箱子内有物品会高亮显示。"
-			},
-		},
+				HOVER = "箱子/物品会高亮显示"
+			}
+		}
 	},
 	highlighting_color = {
-		LABEL = "Highlighting Color",
-		HOVER = "The color to use for highlighting.",
+		LABEL = "高亮颜色",
+		HOVER = "高亮显示时的颜色",
 		OPTIONS = {
 			["RED"] = {
-				DESCRIPTION = "Red",
-				HOVER = "Red",
+				DESCRIPTION = "红色",
+				HOVER = "红色"
 			},
 			["GREEN"] = {
-				DESCRIPTION = "Green",
-				HOVER = "Green",
+				DESCRIPTION = "绿色",
+				HOVER = "绿色"
 			},
 			["BLUE"] = {
-				DESCRIPTION = "Blue",
-				HOVER = "Blue",
+				DESCRIPTION = "蓝色",
+				HOVER = "蓝色"
 			},
 			["LIGHT_BLUE"] = {
-				DESCRIPTION = "Light Blue",
-				HOVER = "Light Blue",
+				DESCRIPTION = "亮蓝色",
+				HOVER = "亮蓝色",
 			},
 			["PURPLE"] = {
-				DESCRIPTION = "Purple",
-				HOVER = "Purple",
+				DESCRIPTION = "紫色",
+				HOVER = "紫色"
 			},
 			["YELLOW"] = {
-				DESCRIPTION = "Yellow",
-				HOVER = "Yellow",
+				DESCRIPTION = "黄色",
+				HOVER = "黄色"
 			},
 			["WHITE"] = {
-				DESCRIPTION = "White",
-				HOVER = "White",
+				DESCRIPTION = "白色",
+				HOVER = "白色",
 			},
 			["ORANGE"] = {
-				DESCRIPTION = "Orange",
-				HOVER = "Orange",
+				DESCRIPTION = "橙色",
+				HOVER = "橙色",
 			},
 			["PINK"] = {
-				DESCRIPTION = "Pink",
-				HOVER = "Pink",
+				DESCRIPTION = "粉色",
+				HOVER = "粉色",
 			},
 		},
 	},
 	fuel_highlighting = {
 		LABEL = "燃料高亮显示",
-		HOVER = "是否开启燃料高亮显示。",
+		HOVER = "是否启用燃料高亮显示",
 		OPTIONS = {
 			["false"] = {
 				DESCRIPTION = "否",
-				HOVER = "燃料高亮显示模式关闭。"
+				HOVER = "禁用燃料高亮显示"
 			},
 			["true"] = {
 				DESCRIPTION = "是",
-				HOVER = "燃料高亮显示模式开启。"
-			},
-		},
+				HOVER = "启用燃料高亮显示"
+			}
+		}
 	},
 	fuel_highlighting_color = {
-		LABEL = "Fuel Highlighting Color",
-		HOVER = "The color to use for fuel highlighting.",
+		LABEL = "燃料高亮颜色",
+		HOVER = "燃料高亮显示时的颜色",
 		OPTIONS = {
 			["RED"] = {
-				DESCRIPTION = "Red",
-				HOVER = "Red",
+				DESCRIPTION = "红色",
+				HOVER = "红色"
 			},
 			["GREEN"] = {
-				DESCRIPTION = "Green",
-				HOVER = "Green",
+				DESCRIPTION = "绿色",
+				HOVER = "绿色"
 			},
 			["BLUE"] = {
-				DESCRIPTION = "Blue",
-				HOVER = "Blue",
+				DESCRIPTION = "蓝色",
+				HOVER = "蓝色"
 			},
 			["LIGHT_BLUE"] = {
-				DESCRIPTION = "Light Blue",
-				HOVER = "Light Blue",
+				DESCRIPTION = "亮蓝色",
+				HOVER = "亮蓝色",
 			},
 			["PURPLE"] = {
-				DESCRIPTION = "Purple",
-				HOVER = "Purple",
+				DESCRIPTION = "紫色",
+				HOVER = "紫色"
 			},
 			["YELLOW"] = {
-				DESCRIPTION = "Yellow",
-				HOVER = "Yellow",
+				DESCRIPTION = "黄色",
+				HOVER = "黄色"
 			},
 			["WHITE"] = {
-				DESCRIPTION = "White",
-				HOVER = "White",
+				DESCRIPTION = "白色",
+				HOVER = "白色",
 			},
 			["ORANGE"] = {
-				DESCRIPTION = "Orange",
-				HOVER = "Orange",
+				DESCRIPTION = "橙色",
+				HOVER = "橙色",
 			},
 			["PINK"] = {
-				DESCRIPTION = "Pink",
-				HOVER = "Pink",
+				DESCRIPTION = "粉色",
+				HOVER = "粉色",
 			},
 		},
 	},
@@ -1631,7 +1631,7 @@ local chinese = {
 	--------------------------------------------------------------------------
 	display_attack_range = {
 		LABEL = "攻击范围",
-		HOVER = "是否显示攻击范围.",
+		HOVER = "是否显示攻击范围",
 		OPTIONS = {
 			["false"] = {
 				DESCRIPTION = "否",
@@ -1640,8 +1640,8 @@ local chinese = {
 			["true"] = {
 				DESCRIPTION = "Yes",
 				HOVER = "显示攻击范围"
-			},
-		},
+			}
+		}
 	},
 	attack_range_type = {
 		LABEL = "攻击范围类型",
@@ -1656,39 +1656,38 @@ local chinese = {
 				HOVER = "显示攻击范围"
 			},
 			["both"] = {
-				DESCRIPTION = "两者",
+				DESCRIPTION = "兼用",
 				HOVER = "同时显示敲击和攻击范围"
-			},
-
-		},
+			}
+		}
 	},
 	hover_range_indicator = {
-		LABEL = "鼠标放置显示物品生效范围",
-		HOVER = "将鼠标放置于物品上时该物品的生效范围是否显示。",
+		LABEL = "物品范围",
+		HOVER = "是否显示鼠标悬停物品的生效范围。",
 		OPTIONS = {
 			["false"] = {
 				DESCRIPTION = "否",
-				HOVER = "物品范围不显示。"
+				HOVER = "不显示物品范围"
 			},
 			["true"] = {
 				DESCRIPTION = "是",
-				HOVER = "物品范围将显示。"
-			},
-		},
+				HOVER = "显示物品范围。"
+			}
+		}
 	},
 	boss_indicator = {
 		LABEL = "Boss 指示器",
-		HOVER = "是否开启 Boss 指示器功能。",
+		HOVER = "是否显示 Boss 指示器功能。",
 		OPTIONS = {
 			["false"] = {
 				DESCRIPTION = "否",
-				HOVER = "Boss指示器不会显示。"
+				HOVER = "不显示 Boss 指示器。"
 			},
 			["true"] = {
 				DESCRIPTION = "是",
-				HOVER = "显示Boss指示器。"
-			},
-		},
+				HOVER = "显示 Boss 指示器。"
+			}
+		}
 	},
 	notable_indicator = {
 		LABEL = "其他物品的指示器",
@@ -1696,13 +1695,13 @@ local chinese = {
 		OPTIONS = {
 			["false"] = {
 				DESCRIPTION = "否",
-				HOVER = "指示器将被禁用。"
+				HOVER = "不显示指示器。"
 			},
 			["true"] = {
 				DESCRIPTION = "是",
-				HOVER = "指示器将被显示。"
-			},
-		},
+				HOVER = "显示指示器。"
+			}
+		}
 	},
 	pipspook_indicator = {
 		LABEL = "小惊吓玩具指示器",
@@ -1715,8 +1714,8 @@ local chinese = {
 			["true"] = {
 				DESCRIPTION = "是",
 				HOVER = "显示小惊吓玩具指示器。"
-			},
-		},
+			}
+		}
 	},
 	bottle_indicator = {
 		LABEL = "漂流瓶指示器",
@@ -1729,8 +1728,8 @@ local chinese = {
 			["true"] = {
 				DESCRIPTION = "是",
 				HOVER = "显示漂流瓶指示器。"
-			},
-		},
+			}
+		}
 	},
 	hunt_indicator = {
 		LABEL = "动物脚印指示器",
@@ -1738,77 +1737,77 @@ local chinese = {
 		OPTIONS = {
 			["false"] = {
 				DESCRIPTION = "否",
-				HOVER = "脚印指示器将不会显示。"
+				HOVER = "不显示脚印指示器。"
 			},
 			["true"] = {
 				DESCRIPTION = "是",
-				HOVER = "脚印指示器会被显示。"
-			},
-		},
+				HOVER = "显示脚印指示器。"
+			}
+		}
 	},
 	orchestrina_indicator = {
-		LABEL = "Archive Puzzle Helper",
-		HOVER = "Whether the solution to the puzzle is displayed or not.",
+		LABEL = "远古迷宫",
+		HOVER = "是否显示远古迷宫的答案。",
 		OPTIONS = {
 			["false"] = {
-				DESCRIPTION = "No",
-				HOVER = "The solution is not displayed."
+				DESCRIPTION = "否",
+				HOVER = "不显示答案。"
 			},
 			["true"] = {
-				DESCRIPTION = "Yes",
-				HOVER = "The solution is displayed."
+				DESCRIPTION = "是",
+				HOVER = "显示答案。"
 			}
 		}
 	},
 	lightningrod_range = {
 		LABEL = "避雷针范围",
-		HOVER = "避雷针生效范围的生效方式。",
+		HOVER = "避雷针生效范围的显示方式。",
 		OPTIONS = {
 			["0"] = {
-				DESCRIPTION = "关闭",
+				DESCRIPTION = "禁用",
 				HOVER = "不显示避雷针的生效范围。"
 			},
 			["1"] = {
 				DESCRIPTION = "策略性地显示",
-				HOVER = "只在放置避雷针时、使用草叉时、种植时才会显示生效范围。"
+				HOVER = "只在放置避雷针时、使用草叉时、种植时显示生效范围。"
 			},
 			["2"] = {
 				DESCRIPTION = "总是",
 				HOVER = "总是显示避雷针的生效范围。"
-			},
-		},
+			}
+		}
 	},
 	blink_range = {
 		LABEL = "瞬移范围",
-		HOVER = "你是否可以看见你的瞬移的范围，如灵魂跳跃，橙色法杖等。",
+		HOVER = "是否显示你的瞬移的范围，如灵魂跳跃，橙色法杖等。",
 		OPTIONS = {
 			["false"] = {
 				DESCRIPTION = "否",
-				HOVER = "瞬移范围将不会被显示。"
+				HOVER = "不显示瞬移范围。"
 			},
 			["true"] = {
 				DESCRIPTION = "是",
-				HOVER = "瞬移范围将会被显示。"
-			},
-		},
+				HOVER = "显示瞬移范围。"
+			}
+		}
 	},
 	wortox_soul_range = {
 		LABEL = "沃拓克斯灵魂范围",
-		HOVER = "开启后可以看到沃拓克斯拾取灵魂的范围和灵魂治疗范围。",
+		HOVER = "是否显示沃拓克斯拾取灵魂的范围和灵魂治疗范围。",
 		OPTIONS = {
 			["false"] = {
 				DESCRIPTION = "否",
-				HOVER = "灵魂范围功能禁用。"
+				HOVER = "不显示灵魂范围功能。"
 			},
 			["true"] = {
 				DESCRIPTION = "是",
-				HOVER = "灵魂范围功能启用。"
-			},
-		},
+				HOVER = "显示灵魂范围功能。"
+			}
+		}
 	},
 	battlesong_range = {
 		LABEL = "战歌生效范围",
-		HOVER = "战歌生效范围是否会被显示。",
+		HOVER = "如何显示战歌的生效范围。",
 		OPTIONS = {
 			["none"] = {
 				DESCRIPTION = "无",
@@ -1823,10 +1822,10 @@ local chinese = {
 				HOVER = "显示你被战歌鼓舞的生效范围。"
 			},
 			["both"] = {
-				DESCRIPTION = "两者",
+				DESCRIPTION = "兼用",
 				HOVER = "同时显示脱离战歌和被战歌鼓舞的生效范围"
-			},
-		},
+			}
+		}
 	},
 	klaus_sack_markers = {
 		LABEL = "Loot Stash Markers (Server Only)",
@@ -1844,21 +1843,21 @@ local chinese = {
 	},
 	sinkhole_marks = {
 		LABEL = "落水洞标记",
-		HOVER = "如何显示落水洞的标记。",
+		HOVER = "如何显示落水洞的着色标记。",
 		OPTIONS = {
 			["0"] = {
 				DESCRIPTION = "无",
-				HOVER = "不做任何落水洞的着色标记。"
+				HOVER = "不着色标记任何落水洞洞口。"
 			},
 			["1"] = {
 				DESCRIPTION = "仅地图模式",
-				HOVER = "只会显示在地图图标上。"
+				HOVER = "仅着色标记地图图标。"
 			},
 			["2"] = {
-				DESCRIPTION = "两者",
-				HOVER = "同时显示在地图图标和落水洞本身上"
-			},
-		},
+				DESCRIPTION = "兼用",
+				HOVER = "同时着色标记地图图标和落水洞洞口。"
+			}
+		}
 	},
 	--------------------------------------------------------------------------
 	--[[ Food Related ]]
@@ -1869,27 +1868,27 @@ local chinese = {
 		OPTIONS = {
 			["false"] = {
 				DESCRIPTION = "否",
-				HOVER = "不显示食物信息。",
+				HOVER = "不显示食物信息。"
 			},
 			["true"] = {
 				DESCRIPTION = "是",
 				HOVER = "显示食物信息。"
-			},
-		},
+			}
+		}
 	},
 	food_style = {
 		LABEL = "食物属性格式",
-		HOVER = "食物属性信息详细或简短展示。",
+		HOVER = "如何显示食物属性信息。",
 		OPTIONS = {
 			["short"] = {
-				DESCRIPTION = "简短",
+				DESCRIPTION = "精简",
 				HOVER = "+X / -X / +X"
 			},
 			["long"] = {
 				DESCRIPTION = "详细",
-				HOVER = "饥饿度： +X / 理智值： -X / 生命值： +X"
-			},
-		},
+				HOVER = "饥饿：+X / 理智：-X / 生命：+X"
+			}
+		}
 	},
 	food_order = {
 		LABEL = "食物属性显示顺序",
@@ -1897,156 +1896,156 @@ local chinese = {
 		OPTIONS = {
 			["interface"] = {
 				DESCRIPTION = "界面",
-				HOVER = "饥饿值 / 理智值 / 生命值"
+				HOVER = "饥饿 / 理智 / 生命"
 			},
 			["wiki"] = {
 				DESCRIPTION = "维基",
-				HOVER = "生命值 / 饥饿值 / 理智值"
-			},
-		},
+				HOVER = "生命 / 饥饿 / 理智"
+			}
+		}
 	},
 	food_units = {
-		LABEL = "食物系数显示",
-		HOVER = "是否显示食物的系数（果、菜、蛋度等等）",
+		LABEL = "食物系数",
+		HOVER = "是否显示食物的系数（果、菜、蛋度等等）。",
 		OPTIONS = {
 			["false"] = {
 				DESCRIPTION = "否",
-				HOVER = "食物度功能禁用。"
+				HOVER = "不显示食物度。"
 			},
 			["true"] = {
 				DESCRIPTION = "是",
-				HOVER = "食物度功能启用。"
-			},
-		},
+				HOVER = "显示食物度。"
+			}
+		}
 	},
 	food_effects = {
-		LABEL = "食物加成属性显示",
-		HOVER = "食物的特殊加成属性是否会显示。",
+		LABEL = "食物加成属性",
+		HOVER = "是否显示食物的特殊加成属性。",
 		OPTIONS = {
 			["false"] = {
 				DESCRIPTION = "否",
-				HOVER = "特殊的食物属性将不会被显示。"
+				HOVER = "不显示特殊的食物属性。"
 			},
 			["true"] = {
 				DESCRIPTION = "是",
-				HOVER = "特殊的食物属性将会被显示。"
-			},
-		},
+				HOVER = "显示特殊的食物属性。"
+			}
+		}
 	},
 	stewer_chef = {
 		LABEL = "烹饪厨师显示",
-		HOVER = "这个料理的制作人的信息是否会被显示。",
+		HOVER = "是否显示料理的制作人。",
 		OPTIONS = {
 			["false"] = {
 				DESCRIPTION = "否",
-				HOVER = "不会被显示。"
+				HOVER = "不显示料理的制作人。"
 			},
 			["true"] = {
 				DESCRIPTION = "是",
-				HOVER = "会被显示。"
-			},
-		},
+				HOVER = "显示料理的制作人。"
+			}
+		}
 	},
 	food_memory = {
 		LABEL = "瓦力大厨的食物计时",
-		HOVER = "你的食物计时是否会显示。",
+		HOVER = "是否显示瓦力大厨的食物计时。",
 		OPTIONS = {
 			["false"] = {
 				DESCRIPTION = "否",
-				HOVER = "你的食物计时不会被显示。"
+				HOVER = "不显示食物计时。"
 			},
 			["true"] = {
 				DESCRIPTION = "是",
-				HOVER = "你的食物计时会被显示。"
-			},
-		},
+				HOVER = "显示食物计时。"
+			}
+		}
 	},
 	display_perishable = {
-		LABEL = "Perishing",
-		HOVER = "Whether perishable information is displayed.",
+		LABEL = "腐烂信息",
+		HOVER = "是否显示腐烂信息",
 		OPTIONS = {
 			["false"] = {
-				DESCRIPTION = "No",
-				HOVER = "Perishable information is not shown."
+				DESCRIPTION = "否",
+				HOVER = "不显示腐烂信息"
 			},
 			["true"] = {
-				DESCRIPTION = "Yes",
-				HOVER = "Perishable information is shown."
-			},
-		},
+				DESCRIPTION = "是",
+				HOVER = "显示腐烂信息"
+			}
+		}
 	},
 	--------------------------------------------------------------------------
 	--[[ Information Control ]]
 	--------------------------------------------------------------------------
 	display_yotb_winners = {
-		LABEL = "Pageant Winners [YOTB]",
-		HOVER = "Whether Pageant winners are shown.",
-		OPTIONS = {
-			["false"] = {
-				DESCRIPTION = "No",
-				HOVER = "The pageant winners are not shown.",
-			},
-			["true"] = {
-				DESCRIPTION = "Yes",
-				HOVER = "The pageant winners are shown."
-			},
-		},
-	},
-	display_yotb_appraisal = {
-		LABEL = "Appraisal Values [YOTB]",
-		HOVER = "Whether appraisal values are shown.",
-		OPTIONS = {
-			["false"] = {
-				DESCRIPTION = "No",
-				HOVER = "The appraisal values are not shown.",
-			},
-			["true"] = {
-				DESCRIPTION = "Yes",
-				HOVER = "The appraisal values are shown."
-			},
-		},
-	},
-	display_shared_stats = {
-		LABEL = "玩家列表中的数据",
-		HOVER = "是否将服务器中其他玩家的数据显示在玩家列表中",
+		LABEL = '选美大赛冠军 ["皮弗娄牛之年" 更新]',
+		HOVER = "是否显示选美大赛冠军",
 		OPTIONS = {
 			["false"] = {
 				DESCRIPTION = "否",
-				HOVER = "不显示数据"
+				HOVER = "不显示选美大赛冠军"
 			},
 			["true"] = {
 				DESCRIPTION = "是",
-				HOVER = "显示数据"
-			},
-		},
+				HOVER = "显示选美大赛冠军"
+			}
+		}
 	},
-	display_fishing_information = {
-		LABEL = "Fishing information",
-		HOVER = "Whether fishing information is shown.",
+	display_yotb_appraisal = {
+		LABEL = '评价值 ["皮弗娄牛之年" 更新]',
+		HOVER = "是否显示评价值",
 		OPTIONS = {
 			["false"] = {
 				DESCRIPTION = "No",
-				HOVER = "Fishing information is not shown.",
+				HOVER = "不显示评价值"
 			},
 			["true"] = {
 				DESCRIPTION = "Yes",
-				HOVER = "Fishing information is shown."
+				HOVER = "显示评价值"
+			}
+		}
+	},
+	display_shared_stats = {
+		LABEL = "玩家列表中的数据",
+		HOVER = "是否在玩家列表中显示服务器中其他玩家的数据",
+		OPTIONS = {
+			["false"] = {
+				DESCRIPTION = "否",
+				HOVER = "不显示数据。"
 			},
-		},
+			["true"] = {
+				DESCRIPTION = "是",
+				HOVER = "显示数据。"
+			}
+		}
+	},
+	display_fishing_information = {
+		LABEL = "垂钓信息",
+		HOVER = "是否显示垂钓信息",
+		OPTIONS = {
+			["false"] = {
+				DESCRIPTION = "否",
+				HOVER = "不显示垂钓信息"
+			},
+			["true"] = {
+				DESCRIPTION = "是",
+				HOVER = "显示垂钓信息"
+			}
+		}
 	},
 	display_spawner_information = {
 		LABEL = "生物生成计时器",
 		HOVER = "是否显示生物生成计时信息（猪人、兔人等）。",
 		OPTIONS = {
 			["false"] = {
-				DESCRIPTION = "关闭",
+				DESCRIPTION = "禁用",
 				HOVER = "不显示生物生成计时信息。"
 			},
 			["true"] = {
-				DESCRIPTION = "开启",
+				DESCRIPTION = "启用",
 				HOVER = "显示生物生成计时信息。"
-			},
-		},
+			}
+		}
 	},
 	weapon_damage = {
 		LABEL = "武器伤害值",
@@ -2054,13 +2053,13 @@ local chinese = {
 		OPTIONS = {
 			["false"] = {
 				DESCRIPTION = "否",
-				HOVER = "不显示武器的伤害值。",
+				HOVER = "不显示武器的伤害值。"
 			},
 			["true"] = {
 				DESCRIPTION = "是",
 				HOVER = "显示武器的伤害值。"
-			},
-		},
+			}
+		}
 	},
 	repair_values = {
 		LABEL = "修补数值",
@@ -2068,37 +2067,37 @@ local chinese = {
 		OPTIONS = {
 			["false"] = {
 				DESCRIPTION = "否",
-				HOVER = "不显示物品的修复信息",
+				HOVER = "不显示物品的修复信息。"
 			},
 			["true"] = {
 				DESCRIPTION = "是",
-				HOVER = "显示物品的修复信息。",
-			},
+				HOVER = "显示物品的修复信息。"
+			}
 		}
 	},
 	soil_moisture = {
 		LABEL = "土壤潮湿度",
-		HOVER = "土壤/植物的潮湿度如何显示。",
+		HOVER = "如何显示土壤/植物的潮湿度。",
 		OPTIONS = {
 			["0"] = {
-				DESCRIPTION = "关闭",
-				HOVER = "土壤潮湿度不显示。",
+				DESCRIPTION = "禁用",
+				HOVER = "不显示土壤潮湿度。"
 			},
 			["1"] = {
 				DESCRIPTION = "仅土壤",
-				HOVER = "仅显示土壤的潮湿度。",
+				HOVER = "仅显示土壤的潮湿度。"
 			},
 			["2"] = {
 				DESCRIPTION = "土壤/植株",
-				HOVER = "显示土壤潮湿度和植株耗水率。",
+				HOVER = "显示土壤潮湿度和植株耗水率。"
 			},
 			["3"] = {
 				DESCRIPTION = "土壤，植株，耕地",
-				HOVER = "显示土壤潮湿度，植株耗水率，耕地潮湿度。",
+				HOVER = "显示土壤潮湿度，植株耗水率，耕地潮湿度。"
 			},
 			["4"] = {
 				DESCRIPTION = "全部",
-				HOVER = "显示土壤潮湿度，植株耗水率，总耕地潮湿度。",
+				HOVER = "显示土壤潮湿度，植株耗水率，总耕地潮湿度。"
 			}
 		}
 	},
@@ -2107,78 +2106,78 @@ local chinese = {
 		HOVER = "如何显示土壤/植株的养分值。",
 		OPTIONS = {
 			["0"] = {
-				DESCRIPTION = "关闭",
-				HOVER = "不显示土壤养分值。",
+				DESCRIPTION = "禁用",
+				HOVER = "不显示土壤养分值。"
 			},
 			["1"] = {
 				DESCRIPTION = "仅土壤",
-				HOVER = "仅显示土壤养分值。",
+				HOVER = "仅显示土壤养分值。"
 			},
 			["2"] = {
 				DESCRIPTION = "土壤/植株",
-				HOVER = "显示土壤养分值和植株耗肥率。",
+				HOVER = "显示土壤养分值和植株耗肥率。"
 			},
 			["3"] = {
 				DESCRIPTION = "土壤，植株，耕地",
-				HOVER = "土壤养分值，植株耗肥率，耕地养分值全部显示。",
-			},
+				HOVER = "显示土壤养分值，植株耗肥率，耕地养分值。"
+			}
 			--[[
 			["4"] = {
 				DESCRIPTION = "全部",
-				HOVER = "土壤养分值，植株耗肥率，总耕地养分值将被显示。",
+				HOVER = "显示土壤养分值，植株耗肥率，总耕地养分值。",
 			}
 			--]]
 		}
 	},
 	display_plant_stressors = {
-		LABEL = "植物压力值",
-		HOVER = "决定是否展示植物压力值",
+		LABEL = "植物压力",
+		HOVER = "决定是否显示植物的压力",
 		OPTIONS = {
 			["0"] = {
 				DESCRIPTION = "否",
-				HOVER = "植物压力值将不会显示",
+				HOVER = "植物的压力将不会显示"
 			},
 			["1"] = {
-				DESCRIPTION = "有园艺帽时",
-				HOVER = "如果你身上有，或戴上远古园艺帽时，显示植物的压力值。",
+				DESCRIPTION = "佩戴园艺帽时",
+				HOVER = "如果你身上有，或戴上远古园艺帽时，显示植物的压力"
 			},
 			["2"] = {
 				DESCRIPTION = "总是",
-				HOVER = "总是显示植物的压力值"
+				HOVER = "总是显示植物的压力"
 			}
 		}
 	},
 	display_weighable = {
-		LABEL = "物品的重量数值",
-		HOVER = "决定物品的重量值是否会显示",
+		LABEL = "物品重量",
+		HOVER = "是否显示物品的重量",
 		OPTIONS = {
 			["false"] = {
 				DESCRIPTION = "否",
-				HOVER = "不显示物品的重量值",
+				HOVER = "不显示物品的重量值"
 			},
 			["true"] = {
 				DESCRIPTION = "是",
-				HOVER = "显示物品的重量值",
-			},
+				HOVER = "显示物品的重量值"
+			}
 		}
 	},
 	display_world_events = {
-		LABEL = "显示大世界事件",
-		HOVER = "此选项决定世界事件是否会被显示。世界事件有：猎犬/蠕虫，世界Boss，地震和其他事件。",
+		LABEL = "世界事件",
+		HOVER = "是否显示世界事件。世界事件有：猎犬/蠕虫，Boss，地震和其他事件。",
 		OPTIONS = {
 			["false"] = {
 				DESCRIPTION = "否",
-				HOVER = "不展示世界事件。"
+				HOVER = "不显示世界事件。"
 			},
 			["true"] = {
 				DESCRIPTION = "是",
-				HOVER = "显示大世界事件。"
-			},
-		},
+				HOVER = "显示世界事件。"
+			}
+		}
 	},
 	display_weather = {
-		LABEL = "显示天气信息",
-		HOVER = "此项决定天气信息是否显示。",
+		LABEL = "天气信息",
+		HOVER = "是否显示天气信息。",
 		OPTIONS = {
 			["false"] = {
 				DESCRIPTION = "否",
@@ -2187,72 +2186,72 @@ local chinese = {
 			["true"] = {
 				DESCRIPTION = "是",
 				HOVER = "显示天气信息"
-			},
-		},
+			}
+		}
 	},
 	nightmareclock_display = {
 		LABEL = "洞穴暴动阶段",
-		HOVER = "决定玩家是否可以看到洞穴暴动的具体阶段。",
+		HOVER = "是否显示洞穴暴动的具体阶段。",
 		OPTIONS = {
 			["0"] = {
-				DESCRIPTION = "关闭",
+				DESCRIPTION = "禁用",
 				HOVER = "不显示洞穴暴动的阶段信息。"
 			},
 			["1"] = {
-				DESCRIPTION = "需要铥矿勋章",
-				HOVER = "拥有铥矿勋章时，暴动阶段信息才会显示。"
+				DESCRIPTION = "拥有铥矿勋章",
+				HOVER = "拥有铥矿勋章时显示。"
 			},
 			["2"] = {
-				DESCRIPTION = "开启",
+				DESCRIPTION = "启用",
 				HOVER = "总是显示暴动阶段的信息。"
-			},
-		},
+			}
+		}
 	},
 	display_health = {
 		LABEL = "生命值",
-		HOVER = "生命值的信息是否会被显示。",
+		HOVER = "是否显示生命值的信息。",
 		OPTIONS = {
 			["false"] = {
 				DESCRIPTION = "否",
-				HOVER = "不显示生命值信息"
+				HOVER = "不显示生命值信息。"
 			},
 			["true"] = {
 				DESCRIPTION = "是",
-				HOVER = "显示生命值信息"
-			},
-		},
+				HOVER = "显示生命值信息。"
+			}
+		}
 	},
 	display_mob_attack_damage = {
-		LABEL = "Mob Attack Damage",
-		HOVER = "Whether mob attack damage is shown.",
+		LABEL = "怪物攻击范围",
+		HOVER = "是否显示怪物的攻击范围",
 		OPTIONS = {
 			["false"] = {
-				DESCRIPTION = "No",
-				HOVER = "Mob attack damage is not shown.",
+				DESCRIPTION = "否",
+				HOVER = "不显示怪物的攻击范围"
 			},
 			["true"] = {
-				DESCRIPTION = "Yes",
-				HOVER = "Mob attack damage is shown.",
-			},
-		},
+				DESCRIPTION = "是",
+				HOVER = "显示怪物的攻击范围"
+			}
+		}
 	},
 	growth_verbosity = {
 		LABEL = "植物生长阶段",
-		HOVER = "展示植物生长的具体信息。",
+		HOVER = "显示植物生长的具体信息。",
 		OPTIONS = {
 			["0"] = {
 				DESCRIPTION = "无",
-				HOVER = "完全不展示会生长的物品的信息。"
+				HOVER = "不显示会生长的物品的信息。"
 			},
 			["1"] = {
 				DESCRIPTION = "简短",
-				HOVER = "只显示生长到下一阶段所需的时间。"
+				HOVER = "仅显示生长到下一阶段所需的时间。"
 			},
 			["2"] = {
 				DESCRIPTION = "详细",
 				HOVER = "显示当前阶段名称，阶段的数字，长到下一阶段所需的时间。"
-			},
-		},
+			}
+		}
 	},
 	display_finiteuses = {
 		LABEL = "工具耐久度",
@@ -2265,8 +2264,8 @@ local chinese = {
 			["true"] = {
 				DESCRIPTION = "是",
 				HOVER = "显示跟随者的信息"
-			},
-		},
+			}
+		}
 	},
 	display_timers = {
 		LABEL = "计时器",
@@ -2279,11 +2278,11 @@ local chinese = {
 			["true"] = {
 				DESCRIPTION = "是",
 				HOVER = "开启计时器。"
-			},
-		},
+			}
+		}
 	},
 	display_upgradeable = {
-		LABEL = "可升级物品显示",
+		LABEL = "可升级物品",
 		HOVER = "是否显示可升级物品的信息。",
 		OPTIONS = {
 			["false"] = {
@@ -2293,40 +2292,40 @@ local chinese = {
 			["true"] = {
 				DESCRIPTION = "是",
 				HOVER = "显示可升级的物品的信息，如蜘蛛巢等。"
-			},
-		},
+			}
+		}
 	},
 	naughtiness_verbosity = {
-		LABEL = "淘气值显示",
-		HOVER = "决定以何种形式展示淘气值。Combined Status这个模组显示淘气值的优先度优于本模组。",
+		LABEL = "淘气值",
+		HOVER = "如何显示淘气值。Combined Status 模组的淘气值显示优先于本模组。",
 		OPTIONS = {
 			["0"] = {
 				DESCRIPTION = "禁用",
-				HOVER = "不显示淘气值信息。"
+				HOVER = "不显示淘气值。"
 			},
 			["1"] = {
 				DESCRIPTION = "生物的淘气值",
-				HOVER = "杀死此生物增加多少淘气值会被显示。"
+				HOVER = "显示击杀生物的淘气值。"
 			},
 			["2"] = {
 				DESCRIPTION = "玩家/生物的淘气值",
-				HOVER = "玩家已有的淘气值和生物的淘气值会一同显示。"
-			},
-		},
+				HOVER = "同时显示玩家已有的淘气值和击杀生物的淘气值。"
+			}
+		}
 	},
 	follower_info = {
-		LABEL = "随从的信息",
-		HOVER = "是否会显示你的跟随者的信息。",
+		LABEL = "随从信息",
+		HOVER = "是否显示你的跟随者的信息。",
 		OPTIONS = {
 			["false"] = {
 				DESCRIPTION = "禁用",
-				HOVER = "跟随者的信息不会被显示。"
+				HOVER = "不显示跟随者的信息。"
 			},
 			["true"] = {
 				DESCRIPTION = "启用",
-				HOVER = "跟随者的信息会被显示。"
-			},
-		},
+				HOVER = "显示跟随者的信息。"
+			}
+		}
 	},
 	herd_information = {
 		LABEL = "兽群信息",
@@ -2339,171 +2338,171 @@ local chinese = {
 			["true"] = {
 				DESCRIPTION = "启用",
 				HOVER = "显示兽群的信息。"
-			},
-		},
+			}
+		}
 	},
 	domestication_information = {
-		LABEL = "牛驯服度显示",
-		HOVER = "是否会显示牛的驯服度。",
+		LABEL = "牛驯服度",
+		HOVER = "是否显示牛的驯服度。",
 		OPTIONS = {
 			["false"] = {
 				DESCRIPTION = "禁用",
-				HOVER = "不显示驯服度信息。"
+				HOVER = "不显示牛的驯服度信息。"
 			},
 			["true"] = {
 				DESCRIPTION = "启用",
-				HOVER = "显示驯服度的信息。"
-			},
-		},
+				HOVER = "显示牛的驯服度信息。"
+			}
+		}
 	},
 	display_pollination = {
 		LABEL = "授粉信息",
 		HOVER = "是否显示蜜蜂、蝴蝶的授粉信息。",
 		OPTIONS = {
 			["false"] = {
-				DESCRIPTION = "关闭",
+				DESCRIPTION = "禁用",
 				HOVER = "不显示授粉信息。"
 			},
 			["true"] = {
-				DESCRIPTION = "开启",
-				HOVER = "将显示授粉信息。"
-			},
-		},
+				DESCRIPTION = "启用",
+				HOVER = "显示授粉信息。"
+			}
+		}
 	},
 	display_hunger = {
-		LABEL = "物品的饥饿值",
-		HOVER = "物品饥饿值的具体信息将会显示。",
+		LABEL = "物品饥饿值",
+		HOVER = "如何显示物品的饥饿值。",
 		OPTIONS = {
 			["0"] = {
 				DESCRIPTION = "否",
-				HOVER = "不会显示饥饿值。"
+				HOVER = "不显示饥饿值。"
 			},
 			["1"] = {
-				DESCRIPTION = "标准化",
-				HOVER = "标准的饥饿值显示。"
+				DESCRIPTION = "标准",
+				HOVER = "显示标准的饥饿值。"
 			},
 			["2"] = {
-				DESCRIPTION = "所有",
-				HOVER = "将会显示所有物品的具体饥饿值。"
-			},
-		},
+				DESCRIPTION = "完整",
+				HOVER = "显示完整物品的饥饿值。"
+			}
+		}
 	},
 	display_sanityaura = {
-		LABEL = "精神光环",
-		HOVER = "是否显示精神光环。",
+		LABEL = "理智光环",
+		HOVER = "是否显示理智光环。",
 		OPTIONS = {
 			["false"] = {
 				DESCRIPTION = "否",
-				HOVER = "不显示精神光环。"
+				HOVER = "不显示理智光环。"
 			},
 			["true"] = {
 				DESCRIPTION = "是",
-				HOVER = "显示精神光环。"
-			},
-		},
+				HOVER = "显示理智光环。"
+			}
+		}
 	},
 	item_worth = {
-		LABEL = "显示物品的价值",
-		HOVER = "是否会显示物品的价值。",
+		LABEL = "物品价值",
+		HOVER = "是否会显示物品的黄金或金币价值。",
 		OPTIONS = {
 			["false"] = {
 				DESCRIPTION = "否",
-				HOVER = "不会显示物品值多少黄金或金币。"
+				HOVER = "不显示物品的价值。"
 			},
 			["true"] = {
 				DESCRIPTION = "是",
-				HOVER = "显示物品值多少黄金或金币。"
-			},
-		},
+				HOVER = "显示物品值的价值。"
+			}
+		}
 	},
 	appeasement_value = {
-		LABEL = "显示蚁狮献祭时间的信息",
+		LABEL = "蚁狮",
 		HOVER = "是否显示蚁狮献祭时间和作乱的信息。",
 		OPTIONS = {
 			["false"] = {
 				DESCRIPTION = "否",
-				HOVER = "不会展示蚁狮相关的信息。"
+				HOVER = "不显示蚁狮的信息。"
 			},
 			["true"] = {
 				DESCRIPTION = "是",
-				HOVER = "将会展示蚁狮的信息。"
-			},
-		},
+				HOVER = "显示蚁狮的信息。"
+			}
+		}
 	},
 	fuel_verbosity = {
-		LABEL = "燃料信息",
-		HOVER = "燃料的信息如何显示。",
+		LABEL = "燃料",
+		HOVER = "如何显示燃料的信息。",
 		OPTIONS = {
 			["0"] = {
 				DESCRIPTION = "无",
 				HOVER = "不显示燃料信息"
 			},
 			["1"] = {
-				DESCRIPTION = "标准化",
+				DESCRIPTION = "标准",
 				HOVER = "显示标准的燃料信息"
 			},
 			["2"] = {
-				DESCRIPTION = "最大化",
+				DESCRIPTION = "全面",
 				HOVER = "显示全面的燃料信息"
-			},
-		},
+			}
+		}
 	},
 	--------------------------------------------------------------------------
 	--[[ Miscellaneous ]]
 	--------------------------------------------------------------------------
 	display_crafting_lookup_button = {
-		LABEL = "Crafting Lookup Button",
-		HOVER = "Whether the crafting lookup button is displayed or not.",
+		LABEL = "建造查看按钮",
+		HOVER = "是否显示建造查看按钮",
 		OPTIONS = {
 			["false"] = {
-				DESCRIPTION = "No",
-				HOVER = "The button is not shown."
+				DESCRIPTION = "否",
+				HOVER = "不显示按钮"
 			},
 			["true"] = {
 				DESCRIPTION = "Yes",
-				HOVER = "The button is shown."
+				HOVER = "显示按钮"
 			},
 		},
 	},
 	display_insight_menu_button = {
-		LABEL = "Insight Menu Button",
-		HOVER = "Whether the insight menu button is displayed or not.",
+		LABEL = "Insight 目录按钮",
+		HOVER = "是否显示 Insight 目录按钮",
 		OPTIONS = {
 			["false"] = {
-				DESCRIPTION = "No",
-				HOVER = "The button is not shown."
+				DESCRIPTION = "否",
+				HOVER = "不显示按钮"
 			},
 			["true"] = {
-				DESCRIPTION = "Yes",
-				HOVER = "The button is shown."
+				DESCRIPTION = "是",
+				HOVER = "显示按钮"
 			},
 		},
 	},
 	extended_info_indicator = {
-		LABEL = "More Information Hint",
-		HOVER = "Whether an asterisk is present for entities with more information.",
+		LABEL = "更多信息提示",
+		HOVER = "是否在有更多信息的实体上显示星号",
 		OPTIONS = {
 			["false"] = {
-				DESCRIPTION = "No",
-				HOVER = "The indicator is not shown."
+				DESCRIPTION = "否",
+				HOVER = "不显示星号"
 			},
 			["true"] = {
-				DESCRIPTION = "Yes",
-				HOVER = "The indicator is shown."
+				DESCRIPTION = "是",
+				HOVER = "显示星号"
 			},
 		},
 	},
 	unrandomizer = {
-		LABEL = "Unrandomizer",
-		HOVER = "[Server Only] \"Solves\" the randomness of some situations.",
+		LABEL = "去随机化",
+		HOVER = '[服务器] 是否 "移除" 某些情况下的随机性.',
 		OPTIONS = {
 			["false"] = {
-				DESCRIPTION = "No",
-				HOVER = "Off"
+				DESCRIPTION = "否",
+				HOVER = "禁用"
 			},
 			["true"] = {
-				DESCRIPTION = "Yes",
-				HOVER = "On"
+				DESCRIPTION = "是",
+				HOVER = "启用"
 			}
 		}
 	},
@@ -2513,42 +2512,42 @@ local chinese = {
 		OPTIONS = {
 			["false"] = {
 				DESCRIPTION = "否",
-				HOVER = "伤害按照原始数据计算。"
+				HOVER = "显示伤害的原始数据。"
 			},
 			["true"] = {
 				DESCRIPTION = "是",
-				HOVER = "伤害将按照玩家拥有的加成和削弱状态来计算。"
-			},
-		},
+				HOVER = "显示伤害及其加成和削弱状态后的数据。"
+			}
+		}
 	},
 	info_preload = {
-		LABEL = "Information preloading",
-		HOVER = "Whether information is preloaded when entities become visible. Trades network usage for faster performance. Recommended to use \"All\".",
+		LABEL = "信息预载",
+		HOVER = '是否预先加载可见范围内所有实体的信息。消耗更多网络以获取更好的表现。推荐使用 "所有"。',
 		OPTIONS = {
 			["0"] = {
-				DESCRIPTION = "No",
-				HOVER = "SEVERE FPS DROP! NOT RECOMMENDED!" -- most severe fps drop
+				DESCRIPTION = "否",
+				HOVER = "严重帧数降低，不推荐" -- most severe fps drop
 			},
 			["1"] = {
-				DESCRIPTION = "Containers",
-				HOVER = "POSSIBLE FPS DROP. NOT RECOMMENDED. CAN USE FOR SMALL, CLEAN BASES."
+				DESCRIPTION = "容器",
+				HOVER = "小幅帧数降低，不推荐。可用于小型简单的基地。"
 			},
 			["2"] = {
-				DESCRIPTION = "All",
-				HOVER = "FASTEST. RECOMMENDED."
-			},
-		},
+				DESCRIPTION = "所有",
+				HOVER = "最高帧率，推荐。"
+			}
+		}
 	},
 	refresh_delay = {
 		LABEL = "信息刷新延时",
-		HOVER = "设定对同一物品的信息多久一次更新。",
+		HOVER = "多久更新物品的信息。",
 		OPTIONS = {
 			["true"] = {
 				DESCRIPTION = "自动设定",
-				HOVER = "取决于玩家和游戏性能，动态更新。"
+				HOVER = "基于玩家和游戏性能，动态更新。"
 			},
 			["0"] = {
-				DESCRIPTION = "无设定",
+				DESCRIPTION = "实时",
 				HOVER = "信息实时更新。"
 			},
 			["0_25"] = {
@@ -2566,14 +2565,28 @@ local chinese = {
 			["3"] = {
 				DESCRIPTION = "3秒",
 				HOVER = "信息每3秒更新。"
-			},
-		},
+			}
+		}
 	},
 	--------------------------------------------------------------------------
 	--[[ Debugging ]]
 	--------------------------------------------------------------------------
+	log_reporter = {
+		LABEL = "日志报告器",
+		HOVER = "提供游戏内手动记录日志的按钮，尝试自动报告错误。日志包含调试、Mod、世界信息。",
+		OPTIONS = {
+			["false"] = {
+				DESCRIPTION = "否",
+				HOVER = "禁用日志报告器。"
+			},
+			["true"] = {
+				DESCRIPTION = "Yes",
+				HOVER = "启用日志报告器。"
+			}
+		}
+	},
 	crash_reporter = {
-		LABEL = "崩溃报错器",
+		LABEL = "崩溃报告器",
 		HOVER = "**尝试**自动上报你的崩溃（调试情况，模组，世界信息）至我的服务器。",
 		OPTIONS = {
 			["false"] = {
@@ -2583,65 +2596,66 @@ local chinese = {
 			["true"] = {
 				DESCRIPTION = "是",
 				HOVER = "开启崩溃报告器。"
-			},
-		},
+			}
+		}
 	},
 	DEBUG_SHOW_NOTIMPLEMENTED = {
-		LABEL = "执行调试展示信息",
+		LABEL = "执行调试显示信息",
 		HOVER = "如果游戏内元件来源未明，错误自于某个模组时，发出警告并显示其来源。",
 		OPTIONS = {
 			["false"] = {
 				DESCRIPTION = "否",
-				HOVER = "未找出错误原因时，不会发出警告。"
+				HOVER = "未找出错误原因时，不发出警告。"
 			},
 			["true"] = {
 				DESCRIPTION = "是",
-				HOVER = "未找出错误原因时，将会向你发出警告。"
-			},
-		},
+				HOVER = "未找出错误原因时，发出警告。"
+			}
+		}
 	},
 	DEBUG_SHOW_DISABLED = {
-		LABEL = "禁用调试展示",
-		HOVER = "发出警告，显示我手动禁用的元件。",
+		LABEL = "禁用调试显示",
+		HOVER = "发出警告，显示我手动禁用的组件。",
 		OPTIONS = {
 			["false"] = {
 				DESCRIPTION = "否",
-				HOVER = "不会展示已禁用的描述符的信息。"
+				HOVER = "不显示已禁用的描述符的信息。"
 			},
 			["true"] = {
 				DESCRIPTION = "是",
 				HOVER = "显示已禁用的描述符的信息。"
-			},
-		},
+			}
+		}
 	},
 	DEBUG_SHOW_PREFAB = {
 		LABEL = "预设调试显示",
-		HOVER = "在物品上显示预设选项的名称。",
+		HOVER = "在物品上显示实体的预设名称。",
 		OPTIONS = {
 			["false"] = {
 				DESCRIPTION = "否",
-				HOVER = "不显示物品的预设项信息。"
+				HOVER = "不显示物品的预设名称。"
 			},
 			["true"] = {
 				DESCRIPTION = "否",
-				HOVER = "显示物品的预设项信息。"
-			},
-		},
+				HOVER = "显示物品的预设名称。"
+			}
+		}
 	},
-	DEBUG_ENABLED = { -- this will need revision at some point. dunno why i wrote the original like that.
+	DEBUG_ENABLED = {
+		-- this will need revision at some point. dunno why i wrote the original like that.
 		LABEL = "开启调试功能",
-		HOVER = "打开你的Insight的调试功能。",
+		HOVER = "打开你的 Insight 调试功能。",
 		OPTIONS = {
 			["false"] = {
 				DESCRIPTION = "否",
-				HOVER = "不显示禁用的描述选项"
+				HOVER = "不显示调试信息"
 			},
 			["true"] = {
 				DESCRIPTION = "是",
-				HOVER = "显示禁用的描述选项"
-			},
-		},
-	},
+				HOVER = "显示调试信息"
+			}
+		}
+	}
 }
 translations["zh"] = chinese
 translations["ch"] = chinese
@@ -2684,7 +2698,7 @@ local function T(x) -- Translate
 	for field in string_gmatch(x, "[^%][^.]+") do
 		current = current[field]
 		backup = backup[field]
-	
+
 		if not current then
 			current = backup -- this could also be just "break", but that would cause translation to return a table if it was in the middle of a chain. this allows us to resort to the backup and keep going
 			if not backup then
@@ -2702,18 +2716,19 @@ local function T(x) -- Translate
 	return current or backup
 end
 
-description = string_format("[%s] %s\n%s\n%s: %s\n%s: %s\n%s\n%s", 
+description =
+	string_format(
+	"[%s] %s\n%s\n%s: %s\n%s: %s\n%s\n%s",
 	--locale or "?", tostring(folder_name), tostring(IsDST),
-	locale or T"ds_not_enabled", 
-	T"mod_explanation", 
-	T"config_disclaimer", 
-
-	T"version", version, 
-	T"latest_update", (IsDST and T"update_info" or T"update_info_ds"), 
-
-	T"crashreporter_info",
-
-	(IsDST and T"config_paths" or "")
+	locale or T "ds_not_enabled",
+	T "mod_explanation",
+	T "config_disclaimer",
+	T "version",
+	version,
+	T "latest_update",
+	(IsDST and T "update_info" or T "update_info_ds"),
+	T "crashreporter_info",
+	(IsDST and T "config_paths" or "")
 )
 
 -- Functions
@@ -2721,59 +2736,58 @@ local function AddSectionTitle(title) -- 100% stole this idea from ReForged. Did
 	if IsDST then
 		return {
 			name = title:upper(), -- avoid conflicts
-			label = title, 
+			label = title,
 			options = {{description = "", data = 0}},
 			default = 0,
-			tags = {"ignore"},
+			tags = {"ignore"}
 		}
 	else
 		return {tags = {"ignore"}}
 	end
 end
 
-
 configuration_options = {
-	AddSectionTitle(T"sectiontitle_formatting"),
+	AddSectionTitle(T "sectiontitle_formatting"),
 	{
 		name = "language", -- name of option -- header for option in dst
 		options = {
 			{data = "automatic"},
 			{data = "en"},
-			{data = "zh"},
-		}, 
+			{data = "zh"}
+		},
 		default = "automatic",
 		client = true,
-		tags = {},
+		tags = {}
 	},
 	{
 		name = "info_style",
 		options = {
 			{data = "text"},
-			{data = "icon"},
-		}, 
+			{data = "icon"}
+		},
 		default = "text",
 		client = true,
-		tags = {},
+		tags = {}
 	},
 	{
 		name = "text_coloring",
 		options = {
 			{data = false},
-			{data = true},
-		}, 
+			{data = true}
+		},
 		default = true,
 		client = true,
-		tags = {},
+		tags = {}
 	},
 	{
 		name = "alt_only_information",
 		options = {
 			{data = false},
-			{data = true},
-		}, 
+			{data = true}
+		},
 		default = false,
 		client = true,
-		tags = {},
+		tags = {}
 	},
 	--[[
 	{
@@ -2792,11 +2806,11 @@ configuration_options = {
 		options = {
 			{data = 0},
 			{data = 1},
-			{data = 2},
-		}, 
+			{data = 2}
+		},
 		default = 2,
 		client = true,
-		tags = {},
+		tags = {}
 	},
 	{
 		name = "time_style",
@@ -2806,22 +2820,22 @@ configuration_options = {
 			{data = "both"},
 			{data = "gametime_short"},
 			{data = "realtime_short"},
-			{data = "both_short"},
+			{data = "both_short"}
 			--{data = "none"},
-		}, 
+		},
 		default = "gametime",
 		client = true,
-		tags = {},
+		tags = {}
 	},
 	{
 		name = "highlighting",
 		options = {
 			{data = false},
-			{data = true},
-		}, 
+			{data = true}
+		},
 		default = true,
 		client = true,
-		tags = {},
+		tags = {}
 	},
 	{
 		name = "highlighting_color",
@@ -2838,17 +2852,17 @@ configuration_options = {
 		}, 
 		default = "GREEN",
 		client = true,
-		tags = {},
+		tags = {}
 	},
 	{
 		name = "fuel_highlighting",
 		options = {
 			{data = false},
-			{data = true},
-		}, 
+			{data = true}
+		},
 		default = false,
 		client = true,
-		tags = {},
+		tags = {}
 	},
 	{
 		name = "fuel_highlighting_color",
@@ -2865,126 +2879,126 @@ configuration_options = {
 		}, 
 		default = "RED",
 		client = true,
-		tags = {},
+		tags = {}
 	},
 	AddSectionTitle(T"sectiontitle_indicators"),
 	{
 		name = "display_attack_range",
 		options = {
 			{data = false},
-			{data = true},
+			{data = true}
 		},
 		default = true,
-		tags = {"undefined"},
+		tags = {"undefined"}
 	},
 	{
 		name = "attack_range_type",
 		options = {
 			{data = "hit"},
 			{data = "attack"},
-			{data = "both"},
+			{data = "both"}
 		},
 		default = "hit",
 		client = true,
-		tags = {"undefined"},
+		tags = {"undefined"}
 	},
 	{
 		name = "hover_range_indicator",
 		options = {
 			{data = false},
-			{data = true},
+			{data = true}
 		},
 		default = true,
 		client = true,
-		tags = {},
+		tags = {}
 	},
 	{
 		name = "boss_indicator",
 		options = {
 			{data = false},
-			{data = true},
-		}, 
+			{data = true}
+		},
 		default = true,
 		client = true,
-		tags = {},
+		tags = {}
 	},
 	{
 		name = "notable_indicator",
 		options = {
 			{data = false},
-			{data = true},
-		}, 
+			{data = true}
+		},
 		default = true,
 		client = true,
-		tags = {},
+		tags = {}
 	},
 	{
 		name = "pipspook_indicator",
 		options = {
 			{data = false},
-			{data = true},
-		}, 
+			{data = true}
+		},
 		default = true,
-		tags = {"dst_only"},
+		tags = {"dst_only"}
 	},
 	{
 		name = "bottle_indicator",
 		options = {
 			{data = false},
-			{data = true},
-		}, 
+			{data = true}
+		},
 		default = true,
 		client = true,
-		tags = {},
+		tags = {}
 	},
 	{
 		name = "hunt_indicator",
 		options = {
 			{data = false},
-			{data = true},
-		}, 
+			{data = true}
+		},
 		default = true,
-		tags = {"undefined"},
+		tags = {"undefined"}
 	},
 	{
 		name = "orchestrina_indicator",
 		options = {
 			{data = false},
-			{data = true},
-		}, 
+			{data = true}
+		},
 		default = true,
-		tags = {"dst_only", "undefined"},
+		tags = {"dst_only", "undefined"}
 	},
 	{
 		name = "lightningrod_range",
 		options = {
 			{data = 0},
 			{data = 1},
-			{data = 2},
-		}, 
+			{data = 2}
+		},
 		default = 1,
 		client = true,
-		tags = {},
+		tags = {}
 	},
 	{
 		name = "blink_range",
 		options = {
 			{data = false},
-			{data = true},
-		}, 
+			{data = true}
+		},
 		default = true,
 		client = true,
-		tags = {},
+		tags = {}
 	},
 	{
 		name = "wortox_soul_range",
 		options = {
 			{data = false},
-			{data = true},
-		}, 
+			{data = true}
+		},
 		default = true,
 		client = true,
-		tags = {"dst_only"},
+		tags = {"dst_only"}
 	},
 	{
 		name = "battlesong_range",
@@ -2992,11 +3006,11 @@ configuration_options = {
 			{data = "none"},
 			{data = "detach"},
 			{data = "attach"},
-			{data = "both"},
-		}, 
+			{data = "both"}
+		},
 		default = "both",
 		client = true,
-		tags = {"dst_only"},
+		tags = {"dst_only"}
 	},
 	{
 		name = "klaus_sack_markers",
@@ -3012,153 +3026,153 @@ configuration_options = {
 		options = {
 			{data = 0},
 			{data = 1},
-			{data = 2},
-		}, 
+			{data = 2}
+		},
 		default = 2,
 		client = true,
-		tags = {"dst_only"},
+		tags = {"dst_only"}
 	},
-	AddSectionTitle(T"sectiontitle_foodrelated"),
+	AddSectionTitle(T "sectiontitle_foodrelated"),
 	{
 		name = "display_food",
 		options = {
 			{data = false},
-			{data = true},
-		}, 
+			{data = true}
+		},
 		default = true,
-		tags = {"undefined"},
+		tags = {"undefined"}
 	},
 	{
 		name = "food_style",
 		options = {
 			{data = "short"},
-			{data = "long"},	
-		}, 
+			{data = "long"}
+		},
 		default = "long",
 		client = true,
-		tags = {},
+		tags = {}
 	},
 	{
 		name = "food_order",
 		options = {
 			{data = "interface"},
-			{data = "wiki"},
-		}, 
+			{data = "wiki"}
+		},
 		default = "interface",
 		client = true,
-		tags = {},
+		tags = {}
 	},
 	{
 		name = "food_units",
 		options = {
 			{data = false},
-			{data = true},
-		}, 
+			{data = true}
+		},
 		default = true,
 		client = true,
-		tags = {},
+		tags = {}
 	},
 	{
 		name = "food_effects",
 		options = {
 			{data = false},
-			{data = true},
-		}, 
+			{data = true}
+		},
 		default = true,
 		client = true,
-		tags = {},
+		tags = {}
 	},
 	{
 		name = "stewer_chef",
 		options = {
 			{data = false},
-			{data = true},
-		}, 
+			{data = true}
+		},
 		default = true,
-		tags = {"undefined", "dst_only"},
+		tags = {"undefined", "dst_only"}
 	},
 	{
 		name = "food_memory",
 		options = {
 			{data = false},
-			{data = true},
-		}, 
+			{data = true}
+		},
 		default = true,
 		client = true,
-		tags = {"undefined", "dst_only"},
+		tags = {"undefined", "dst_only"}
 	},
 	{
 		name = "display_perishable",
 		options = {
 			{data = false},
-			{data = true},
-		}, 
+			{data = true}
+		},
 		default = true,
-		tags = {"undefined"},
+		tags = {"undefined"}
 	},
-	AddSectionTitle(T"sectiontitle_informationcontrol"),
+	AddSectionTitle(T "sectiontitle_informationcontrol"),
 	{
 		name = "display_yotb_winners",
 		options = {
 			{data = false},
-			{data = true},
+			{data = true}
 		},
 		default = false,
-		tags = {"dst_only", "undefined"},
+		tags = {"dst_only", "undefined"}
 	},
 	{
 		name = "display_yotb_appraisal",
 		options = {
 			{data = false},
-			{data = true},
+			{data = true}
 		},
 		default = false,
-		tags = {"dst_only", "undefined"},
+		tags = {"dst_only", "undefined"}
 	},
 	{
 		name = "display_shared_stats",
 		options = {
 			{data = false},
-			{data = true},
+			{data = true}
 		},
 		default = true,
-		tags = {"dst_only", "undefined"},
+		tags = {"dst_only", "undefined"}
 	},
 	{
 		name = "display_fishing_information",
 		options = {
 			{data = false},
-			{data = true},
+			{data = true}
 		},
 		default = true,
-		tags = {"undefined"},
+		tags = {"undefined"}
 	},
 	{
 		name = "display_spawner_information",
 		options = {
 			{data = false},
-			{data = true},
+			{data = true}
 		},
 		default = true,
-		tags = {"undefined"},
+		tags = {"undefined"}
 	},
 	{
 		name = "weapon_damage",
 		options = {
 			{data = false},
-			{data = true},
+			{data = true}
 		},
 		default = true,
-		tags = {"undefined"},
+		tags = {"undefined"}
 	},
 	{
 		name = "repair_values",
 		options = {
 			{data = false},
-			{data = true},
+			{data = true}
 		},
 		default = false,
-		tags = {"undefined"},
+		tags = {"undefined"}
 	},
 	{
 		name = "soil_moisture",
@@ -3167,11 +3181,11 @@ configuration_options = {
 			{data = 1},
 			{data = 2},
 			{data = 3},
-			{data = 4},
+			{data = 4}
 		},
 		default = 2,
 		client = true,
-		tags = {"dst_only"},
+		tags = {"dst_only"}
 	},
 	{
 		name = "soil_nutrients",
@@ -3179,207 +3193,207 @@ configuration_options = {
 			{data = 0},
 			{data = 1},
 			{data = 2},
-			{data = 3},
+			{data = 3}
 			--{data = 4},
 		},
 		default = 2,
-		tags = {"dst_only", "undefined"},
+		tags = {"dst_only", "undefined"}
 	},
 	{
 		name = "display_plant_stressors",
 		options = {
 			{data = 0},
 			{data = 1},
-			{data = 2},
+			{data = 2}
 		},
 		default = 2,
-		tags = {"dst_only", "undefined"},
+		tags = {"dst_only", "undefined"}
 	},
 	{
 		name = "display_weighable",
 		options = {
 			{data = false},
-			{data = true},
+			{data = true}
 		},
 		default = false,
-		tags = {"dst_only", "undefined"},
+		tags = {"dst_only", "undefined"}
 	},
 	{
 		name = "display_world_events",
 		options = {
 			{data = false},
-			{data = true},
-		}, 
+			{data = true}
+		},
 		default = true,
-		tags = {"dst_only", "undefined"},
+		tags = {"dst_only", "undefined"}
 	},
 	{
 		name = "display_weather",
 		options = {
 			{data = false},
-			{data = true},
-		}, 
+			{data = true}
+		},
 		default = true,
-		tags = {"dst_only", "undefined"},
+		tags = {"dst_only", "undefined"}
 	},
 	{
 		name = "nightmareclock_display",
 		options = {
 			{data = 0},
 			{data = 1},
-			{data = 2},
-		}, 
+			{data = 2}
+		},
 		default = 2,
-		tags = {"undefined"},
+		tags = {"undefined"}
 	},
 	{
 		name = "display_health",
 		options = {
 			{data = false},
-			{data = true},
-		}, 
+			{data = true}
+		},
 		default = true,
-		tags = {"undefined"},
+		tags = {"undefined"}
 	},
 	{
 		name = "display_mob_attack_damage",
 		options = {
 			{data = false},
-			{data = true},
-		}, 
+			{data = true}
+		},
 		default = true,
-		tags = {"undefined"},
+		tags = {"undefined"}
 	},
 	{
 		name = "growth_verbosity",
 		options = {
 			{data = 0},
 			{data = 1},
-			{data = 2},
-		}, 
+			{data = 2}
+		},
 		default = 1,
-		tags = {"undefined"},
+		tags = {"undefined"}
 	},
 	{
 		name = "display_finiteuses",
 		options = {
 			{data = false},
-			{data = true},
-		}, 
+			{data = true}
+		},
 		default = true,
 		client = true,
-		tags = {},
+		tags = {}
 	},
 	{
 		name = "display_timers",
 		options = {
 			{data = false},
-			{data = true},
-		}, 
+			{data = true}
+		},
 		default = true,
-		tags = {"undefined"},
+		tags = {"undefined"}
 	},
 	{
 		name = "display_upgradeable",
 		options = {
 			{data = false},
-			{data = true},
-		}, 
+			{data = true}
+		},
 		default = false,
-		tags = {"undefined"},
+		tags = {"undefined"}
 	},
 	{
 		name = "naughtiness_verbosity",
 		options = {
 			{data = 0},
 			{data = 1},
-			{data = 2},
-		}, 
+			{data = 2}
+		},
 		default = 2,
-		tags = {"undefined"},
+		tags = {"undefined"}
 	},
 	{
 		name = "follower_info",
 		options = {
 			{data = false},
-			{data = true},
-		}, 
+			{data = true}
+		},
 		default = true,
-		tags = {"undefined"},
+		tags = {"undefined"}
 	},
 	{
 		name = "herd_information",
 		options = {
 			{data = false},
-			{data = true},
-		}, 
+			{data = true}
+		},
 		default = false,
-		tags = {"undefined"},
+		tags = {"undefined"}
 	},
 	{
 		name = "domestication_information",
 		options = {
 			{data = false},
-			{data = true},
-		}, 
+			{data = true}
+		},
 		default = true,
-		tags = {"undefined"},
+		tags = {"undefined"}
 	},
 	{
 		name = "display_pollination",
 		options = {
 			{data = false},
-			{data = true},
+			{data = true}
 		},
 		default = true,
-		tags = {"undefined"},
+		tags = {"undefined"}
 	},
 	{
 		name = "display_hunger",
 		options = {
 			{data = 0},
 			{data = 1},
-			{data = 2},
-		}, 
+			{data = 2}
+		},
 		default = 1,
-		tags = {"undefined"},
+		tags = {"undefined"}
 	},
 	{
 		name = "display_sanityaura",
 		options = {
 			{data = false},
-			{data = true},
-		}, 
+			{data = true}
+		},
 		default = true,
-		tags = {"undefined"},
+		tags = {"undefined"}
 	},
 	{
 		name = "item_worth",
 		options = {
 			{data = false},
-			{data = true},
-		}, 
+			{data = true}
+		},
 		default = true,
-		tags = {"undefined"},
+		tags = {"undefined"}
 	},
 	{
 		name = "appeasement_value",
 		options = {
 			{data = false},
-			{data = true},
-		}, 
+			{data = true}
+		},
 		default = false,
-		tags = {"undefined"},
+		tags = {"undefined"}
 	},
 	{
 		name = "fuel_verbosity",
 		options = {
 			{data = 0},
 			{data = 1},
-			{data = 2},
-		}, 
+			{data = 2}
+		},
 		default = 2,
-		tags = {"undefined"},
+		tags = {"undefined"}
 	},
 	AddSectionTitle(T"sectiontitle_miscellaneous"),
 	{
@@ -3440,10 +3454,10 @@ configuration_options = {
 		options = {
 			--{data = 0}, -- probably not going to let people use this one
 			{data = 1},
-			{data = 2},
+			{data = 2}
 		},
 		default = 2,
-		tags = {"undefined"},
+		tags = {"undefined"}
 	},
 	{
 		name = "refresh_delay",
@@ -3454,59 +3468,59 @@ configuration_options = {
 			{data = "0_25"},
 			{data = "0_5"},
 			{data = 1},
-			{data = 3},
+			{data = 3}
 		},
 		default = true,
-		tags = {"dst_only", "undefined"},
+		tags = {"dst_only", "undefined"}
 	},
-	AddSectionTitle(T"sectiontitle_debugging"),
+	AddSectionTitle(T "sectiontitle_debugging"),
 	{
 		name = "crash_reporter",
 		options = {
 			{data = false},
-			{data = true},
+			{data = true}
 		},
 		default = false,
-		tags = {"independent", "dst_only"},
+		tags = {"independent", "dst_only"}
 	},
 	{
 		name = "DEBUG_SHOW_NOTIMPLEMENTED",
 		options = {
 			{data = false},
-			{data = true},
-		}, 
+			{data = true}
+		},
 		default = false,
 		client = true,
-		tags = {},
+		tags = {}
 	},
 	{
 		name = "DEBUG_SHOW_DISABLED",
 		options = {
 			{data = false},
-			{data = true},
-		}, 
+			{data = true}
+		},
 		default = false,
 		client = true,
-		tags = {},
+		tags = {}
 	},
 	{
 		name = "DEBUG_SHOW_PREFAB",
 		options = {
 			{data = false},
-			{data = true},
+			{data = true}
 		},
 		default = false,
 		client = true,
-		tags = {},
+		tags = {}
 	},
 	{
 		name = "DEBUG_ENABLED",
 		options = {
 			{data = false},
-			{data = true},
+			{data = true}
 		},
 		default = false,
-		tags = {},
+		tags = {}
 	}
 }
 
@@ -3515,7 +3529,7 @@ local function GetDefaultSetting(entry)
 
 	if not entry then
 		local msg = "MAJOR ERROR. ENTRY IS NIL. PLEASE REPORT TO MOD CREATOR."
-		return { description = msg, data = false, hover = msg}
+		return {description = msg, data = false, hover = msg}
 	end
 
 	for i = 1, #entry.options do
@@ -3525,7 +3539,7 @@ local function GetDefaultSetting(entry)
 	end
 
 	local msg = "[DEFAULT???]: \n" .. entry.name .. "|" .. tostring(entry.default)
-	return { description = msg, data = false, hover = msg}
+	return {description = msg, data = false, hover = msg}
 end
 
 local function GetOption(name)
@@ -3556,8 +3570,8 @@ end
 
 for i = 1, #configuration_options do
 	local entry = configuration_options[i]
-	
-	if not HasTag(entry, "ignore") then 
+
+	if not HasTag(entry, "ignore") then
 		entry.label = T(entry.name .. ".LABEL")
 		entry.hover = T(entry.name .. ".HOVER")
 
@@ -3569,11 +3583,10 @@ for i = 1, #configuration_options do
 	end
 end
 
-
-if IsDST then 
+if IsDST then
 	for i = 1, #configuration_options do
 		local entry = configuration_options[i]
-		
+
 		local default = GetDefaultSetting(entry)
 
 		--[[
@@ -3581,11 +3594,14 @@ if IsDST then
 			entry.label = entry.label .. " (Client)" -- Only client can choose
 		end
 		--]]
-
 		if HasTag(entry, "undefined") then -- Server doesn't have to specify
 			entry.original_default = entry.default
 			entry.default = "undefined"
-			entry.options[#entry.options+1] = { description = T"undefined", data = "undefined", hover = T"undefined_description" .. default.description}
+			entry.options[#entry.options + 1] = {
+				description = T "undefined",
+				data = "undefined",
+				hover = T "undefined_description" .. default.description
+			}
 		end
 
 		--v.options[#v.options+1] = { description = "Undefined" , data = "undefined", hover = "Default: " .. default.description }
@@ -3605,8 +3621,7 @@ else
 
 	for i = 1, #configuration_options do
 		local entry = configuration_options[i]
-		
+
 		--v.options[#v.options+1] = { description = "DS", data = "hehe", hover = i}
 	end
-	
 end

--- a/scripts/descriptors/childspawner.lua
+++ b/scripts/descriptors/childspawner.lua
@@ -91,7 +91,7 @@ local function Describe(self, context)
 			end
 
 			regen_time = regen_time and context.time:SimpleProcess(regen_time) or "?"
-			regen = string.format(context.lstr.childspawner.regenerating, to_regen, regen_time)
+			regen = GetDescription(context.lstr.childspawner.regenerating, to_regen, regen_time)
 		end
 	end
 

--- a/scripts/descriptors/debuffable.lua
+++ b/scripts/descriptors/debuffable.lua
@@ -128,7 +128,7 @@ local function Describe(self, context)
 					remaining_time = "No timer specified"
 				end
 				
-				local text = string.format(context.lstr.buff_text, definition.name or ("\"" .. debuffPrefab .. "\""), remaining_time)
+				local text = GetDescription(context.lstr.buff_text, definition.name or ("\"" .. debuffPrefab .. "\""), remaining_time)
 
 				--dprint("server", debuffPrefab, text)
 

--- a/scripts/descriptors/fertilizer.lua
+++ b/scripts/descriptors/fertilizer.lua
@@ -57,7 +57,7 @@ local function Describe(self, context)
 			-- healing over time
 			local healing = TUNING.WORMWOOD_COMPOST_HEAL_VALUES[math.ceil(compost / 8)] or TUNING.WORMWOOD_COMPOST_HEAL_VALUES[1]
 			local duration = healing * (TUNING.WORMWOOD_COMPOST_HEALOVERTIME_TICK / TUNING.WORMWOOD_COMPOST_HEALOVERTIME_HEALTH)
-			compost_value_string = string.format(context.lstr.fertilizer.wormwood.compost_heal, healing, duration)
+			compost_value_string = GetDescription(context.lstr.fertilizer.wormwood.compost_heal, healing, duration)
 		end
 
 		if manure > 0 then

--- a/scripts/descriptors/perishable.lua
+++ b/scripts/descriptors/perishable.lua
@@ -316,7 +316,7 @@ local function Describe(self, context)
 
 		return {
 			priority = 0,
-			description = string.format(context.lstr.perishable.transition, context.lstr.perishable.rot, context.time:SimpleProcess(context.bundleitem.perishremainingtime)),
+			description = GetDescription(context.lstr.perishable.transition, context.lstr.perishable.rot, context.time:SimpleProcess(context.bundleitem.perishremainingtime)),
 			perishmodifier = modifier,
 		}
 	end
@@ -333,8 +333,8 @@ local function Describe(self, context)
 		local time_to_perish = context.time:SimpleProcess(math.abs(data.time_to_perish))
 		local alt_time_to_perish = context.time:SimpleProcess(math.abs(data.alt_time_to_perish))
 
-		description = string.format(context.lstr.perishable.transition, context.lstr.perishable[data.perish_type], time_to_perish)
-		alt_description = string.format(context.lstr.perishable.transition_extended, context.lstr.perishable[data.alt_perish_type], alt_time_to_perish, Round(data.percent * 100, 1))
+		description = GetDescription(context.lstr.perishable.transition, context.lstr.perishable[data.perish_type], time_to_perish)
+		alt_description = GetDescription(context.lstr.perishable.transition_extended, context.lstr.perishable[data.alt_perish_type], alt_time_to_perish, Round(data.percent * 100, 1))
 	end
 
 	return {

--- a/scripts/descriptors/spawner.lua
+++ b/scripts/descriptors/spawner.lua
@@ -39,7 +39,7 @@ local function Describe(self, context)
 	end
 
 	if respawn_time then
-		description = string.format(context.lstr.spawner.next, GetPrefabNameOrElse(self.childname, "\"%s\""), context.time:SimpleProcess(respawn_time))
+		description = GetDescription(context.lstr.spawner.next, GetPrefabNameOrElse(self.childname, "\"%s\""), context.time:SimpleProcess(respawn_time))
 	else
 		alt_description = string.format(context.lstr.spawner.child, GetPrefabNameOrElse(self.childname, "\"%s\""))
 	end

--- a/scripts/language/chinese.lua
+++ b/scripts/language/chinese.lua
@@ -330,7 +330,7 @@ return {
 		uses_plain = "使用",
 		sleepin = "睡觉",
 		fan = "扇风",
-		play = "演奏", -- beefalo horn
+		play = "演奏", -- beefalo horn, could be "吹奏" if it's ONLY for horn
 		hammer = "锤",
 		chop = "砍",
 		mine = "开采",
@@ -374,7 +374,7 @@ return {
 
 	-- fossil_stalker.lua [Prefab]
 	fossil_stalker = {
-		pieces_needed = "有 20%% 几率组装错误在组装上 %s 片后",
+		pieces_needed = "还有 %s 片组装的错误几率为 20%% ",
 		correct = "组装正确",
 		incorrect = "组装错误",
 		gateway_too_far = "这个骷髅距离是 %s 个格子"

--- a/scripts/language/chinese.lua
+++ b/scripts/language/chinese.lua
@@ -70,7 +70,7 @@ return {
 		autumn = "秋天",
 		winter = "冬天",
 		spring = "春天",
-		summer = "夏天"
+		summer = "夏天",
 	},
 
 	-------------------------------------------------------------------------------------------------------------------------
@@ -79,7 +79,7 @@ return {
 	alterguardianhat = {
 		minimum_sanity = "最低<color=SANITY>理智</color>光源: <color=SANITY>%s</color> (<color=SANITY>%s%%</color>)",
 		current_sanity = "你的<color=SANITY>理智</color>: <color=SANITY>%s</color> (<color=SANITY>%s%%</color>)",
-		summoned_gestalt_damage = "召唤<color=ENLIGHTENMENT>月灵</color>造成<color=HEALTH>%s</color>伤害"
+		summoned_gestalt_damage = "召唤<color=ENLIGHTENMENT>月灵</color>造成<color=HEALTH>%s</color>伤害",
 	},
 
 	-- appeasement.lua
@@ -119,7 +119,7 @@ return {
 	-- burnable.lua
 	burnable = {
 		smolder_time = "即将<color=LIGHT>燃起</color>: <color=LIGHT>%s</color>",
-		burn_time = "剩余<color=LIGHT>燃烧时间</color>: <color=LIGHT>%s</color>"
+		burn_time = "剩余<color=LIGHT>燃烧时间</color>: <color=LIGHT>%s</color>",
 	},
 
 	-- canary.lua [Prefab]
@@ -127,14 +127,14 @@ return {
 		gas_level = "<color=#DBC033>空气等级</color>: %s / %s", -- canary, max saturation canary
 		poison_chance = "变为<color=#522E61>有毒</color>几率: <color=#D8B400>%d%%</color>",
 		gas_level_increase = "增加于 %s",
-		gas_level_decrease = "减少于 %s"
+		gas_level_decrease = "减少于 %s",
 	},
 
 	-- catcoonden.lua [Prefab]
 	catcoonden = {
 		lives = catcoon .. "寿命: %s / %s",
 		regenerate = catcoon .. "%s后复活",
-		waiting_for_sleep = "等待附近的玩家走开."
+		waiting_for_sleep = "等待附近的玩家走开.",
 	},
 
 	-- chessnavy.lua
@@ -150,7 +150,7 @@ return {
 		emergency_children = "*<color=MOB_SPAWN><prefab=%s></color>: %s<sub>in</sub> + %s<sub>out</sub> / %s",
 		both_regen = "<color=MOB_SPAWN><prefab=%s></color> & <color=MOB_SPAWN><prefab=%s></color>",
 		regenerating = "$2后$1重新生长",
-		entity = "<color=MOB_SPAWN><prefab=%s></color>"
+		entity = "<color=MOB_SPAWN><prefab=%s></color>",
 	},
 
 	-- combat.lua
@@ -188,7 +188,7 @@ return {
 		["buff_sleepresistance"] = "抵抗<color=MONSTER>睡眠</color>, 持续 %s 秒。",
 		["tillweedsalve_buff"] = "$2 秒内回复 <color=HEALTH>$1 健康</color>。",
 		["healthregenbuff"] = "$2 秒内回复 <color=HEALTH>$1 健康</color>。",
-		["sweettea_buff"] = "$2 秒内回复 <color=SANITY>$1 理智</color>。"
+		["sweettea_buff"] = "$2 秒内回复 <color=SANITY>$1 理智</color>。",
 	},
 
 	-- deerclopsspawner.lua
@@ -210,8 +210,8 @@ return {
 			[TENDENCY.DEFAULT] = "默认",
 			[TENDENCY.ORNERY] = "战斗",
 			[TENDENCY.RIDER] = "骑乘",
-			[TENDENCY.PUDGY] = "肥胖"
-		}
+			[TENDENCY.PUDGY] = "肥胖",
+		},
 	},
 
 	-- drivable.lua
@@ -241,7 +241,7 @@ return {
 		dried = "干货",
 		inedible = "不可食用物",
 		bug = "虫子",
-		seed = "种子"
+		seed = "种子",
 	},
 	edible_foodeffect = {
 		temperature = "温度变化: %s, %s",
@@ -249,7 +249,7 @@ return {
 		surf = "船只速度: %s, %s",
 		autodry = "干燥: %s, %s",
 		instant_temperature = "温度变化: %s, (瞬间)",
-		antihistamine = "花粉症延时: %ss"
+		antihistamine = "花粉症延时: %ss",
 	},
 	foodmemory = "最近食用: %s / %s，将忘记于%s后",
 	wereeater = "已食用<color=MONSTER>怪兽肉</color>: %s / %s, 将消逝于%s后",
@@ -272,7 +272,7 @@ return {
 	farmplantable = {
 		product = "将长成 <color=NATURE><prefab=%s></color>。",
 		nutrient_consumption = "消耗养分: [<color=NATURE>%d<sub>催长剂</sub></color>, <color=CAMO>%d<sub>堆肥</sub></color>, <color=INEDIBLE>%d<sub>粪肥</sub></color>]",
-		good_seasons = "生长季节: %s"
+		good_seasons = "生长季节: %s",
 	},
 
 	-- farmplantstress.lua
@@ -287,7 +287,7 @@ return {
 				[FARM_PLANT_STRESS.MODERATE] = "中",
 				[FARM_PLANT_STRESS.HIGH] = "高"
 			} or
-			{})
+			{}),
 	},
 
 	-- farmsoildrinker.lua
@@ -295,7 +295,7 @@ return {
 		soil_only = "<color=WET>水分</color>: <color=WET>%s<sub> 格</sub></color>",
 		soil_plant = "<color=WET>水分</color>: <color=WET>%s<sub> 格</sub></color> (<color=WET>%s/分<sub>植物</sub></color>)",
 		soil_plant_tile = "<color=WET>水分</color>: <color=WET>%s<sub> 格</sub></color> (<color=WET>%s<sub>植物</sub></color> [<color=#2f96c4>%s<sub>格</sub></color>])<color=WET>/分</color>",
-		soil_plant_tile_net = "<color=WET>水分</color>: <color=WET>%s<sub> 格</sub></color> (<color=WET>%s<sub>植物</sub></color> [<color=#2f96c4>%s<sub>格</sub></color> + <color=SHALLOWS>%s<sub>世界</sub></color> = <color=#DED15E>%+.1f<sub>网</sub></color>])<color=WET>/分</color>"
+		soil_plant_tile_net = "<color=WET>水分</color>: <color=WET>%s<sub> 格</sub></color> (<color=WET>%s<sub>植物</sub></color> [<color=#2f96c4>%s<sub>格</sub></color> + <color=SHALLOWS>%s<sub>世界</sub></color> = <color=#DED15E>%+.1f<sub>网</sub></color>])<color=WET>/分</color>",
 	},
 
 	-- Formula 催长剂, Compost 堆肥, Manure 粪肥 by free translation
@@ -305,7 +305,7 @@ return {
 		--soil_plant_tile = "养分: [%+d<color=NATURE><sub>催</sub></color>, %+d<color=CAMO><sub>堆</sub></color>, %+d<color=INEDIBLE><sub>粪</sub></color>]<sup>格</sup> ([<color=#bee391>%+d<sub>催</sub></color>, <color=#7a9c6e>%+d<sub>堆</sub></color>, <color=INEDIBLE>%+d<sub>便</sub></color>]<sup>plantΔ</sup>   [<color=NATURE>%+d<sub>催</sub></color>, <color=CAMO>%+d<sub>堆</sub></color>, <color=INEDIBLE>%+d<sub>粪</sub></color>]<sup>格Δ</sup>)",
 		--soil_plant_tile = "养分: [%+d<color=NATURE><sub>催</sub></color>, %+d<color=CAMO><sub>堆</sub></color>, %+d<color=INEDIBLE><sub>粪</sub></color>]<sup>格</sup> ([<color=NATURE>%+d<sub>催</sub></color>, <color=CAMO>%+d<sub>堆</sub></color>, <color=INEDIBLE>%+d<sub>便</sub></color>]<sup>plantΔ</sup>   [<color=NATURE>%+d<sub>催</sub></color>, <color=CAMO>%+d<sub>堆</sub></color>, <color=INEDIBLE>%+d<sub>粪</sub></color>]<sup>格Δ</sup>)",
 		soil_plant_tile = "养分: [<color=NATURE>%+d<sub>催</sub></color>, <color=CAMO>%+d<sub>堆</sub></color>, <color=INEDIBLE>%+d<sub>粪</sub></color>]<sub>tile</sub>   (Δ[<color=NATURE>%+d<sub>催</sub></color>, <color=CAMO>%+d<sub>堆</sub></color>, <color=INEDIBLE>%+d<sub>便</sub></color>]<sub>植物</sub> [<color=NATURE>%+d<sub>催</sub></color>, <color=CAMO>%+d<sub>堆</sub></color>, <color=INEDIBLE>%+d<sub>粪</sub></color>]<sub>格Δ</sub>)"
-		--soil_plant_tile_net = "养分: [<color=NATURE>%+d<sub>催</sub></color>, <color=CAMO>%+d<sub>堆</sub></color>, <color=INEDIBLE>%+d<sub>粪</sub></color>] ([<color=NATURE>%+d<sub>催</sub></color>, <color=CAMO>%+d<sub>堆</sub></color>, <color=INEDIBLE>%+d<sub>便</sub></color>] + [<color=NATURE>%+d<sub>催</sub></color>, <color=CAMO>%+d<sub>堆</sub></color>, <color=INEDIBLE>%+d<sub>粪</sub></color>] = [<color=NATURE>%+d<sub>催</sub></color>, <color=CAMO>%+d<sub>堆</sub></color>, <color=INEDIBLE>%+d<sub>粪</sub></color>])"
+		--soil_plant_tile_net = "养分: [<color=NATURE>%+d<sub>催</sub></color>, <color=CAMO>%+d<sub>堆</sub></color>, <color=INEDIBLE>%+d<sub>粪</sub></color>] ([<color=NATURE>%+d<sub>催</sub></color>, <color=CAMO>%+d<sub>堆</sub></color>, <color=INEDIBLE>%+d<sub>便</sub></color>] + [<color=NATURE>%+d<sub>催</sub></color>, <color=CAMO>%+d<sub>堆</sub></color>, <color=INEDIBLE>%+d<sub>粪</sub></color>] = [<color=NATURE>%+d<sub>催</sub></color>, <color=CAMO>%+d<sub>堆</sub></color>, <color=INEDIBLE>%+d<sub>粪</sub></color>])",
 	},
 
 	-- fertilizer.lua
@@ -314,13 +314,13 @@ return {
 		nutrient_value = "养分: [<color=NATURE>%s<sub>催长剂</sub></color>, <color=CAMO>%s<sub>堆肥</sub></color>, <color=INEDIBLE>%s<sub>粪肥</sub></color>]",
 		wormwood = {
 			formula_growth = "你的<color=LIGHT_PINK>开花</color>加速 <color=LIGHT_PINK>%s</color>。",
-			compost_heal = "<color=HEALTH>回复</color> <color=HEALTH>$2</color> 秒你的<color=HEALTH>$1</color>。"
-		}
+			compost_heal = "<color=HEALTH>回复</color> <color=HEALTH>$2</color> 秒你的<color=HEALTH>$1</color>。",
+		},
 	},
 
 	-- fillable.lua
 	fillable = {
-		accepts_ocean_water = "可被海水填充"
+		accepts_ocean_water = "可被海水填充",
 	},
 
 	-- finiteuses.lua
@@ -351,7 +351,7 @@ return {
 		fish = "钓",
 		row = "划",
 		row_fail = "划（失败）",
-		till = "耕种"
+		till = "耕种",
 	},
 
 	-- fishable.lua
@@ -377,7 +377,7 @@ return {
 		pieces_needed = "还有 %s 片组装的错误几率为 20%% ",
 		correct = "组装正确",
 		incorrect = "组装错误",
-		gateway_too_far = "这个骷髅距离是 %s 个格子"
+		gateway_too_far = "这个骷髅距离是 %s 个格子",
 	},
 
 	-- friendlevels.lua
@@ -387,7 +387,7 @@ return {
 	fuel = {
 		fuel = "<color=LIGHT>%s</color> 秒的燃料",
 		fuel_verbose = "<color=LIGHT>%s</color> 秒的<color=LIGHT>%s</color>",
-		type = "燃料类型: %s"
+		type = "燃料类型: %s",
 	},
 
 	-- fueled.lua
@@ -395,7 +395,7 @@ return {
 		time = "<color=LIGHT>燃料</color>持续时间 (<color=LIGHT>%s%%</color>): %s", -- percent, time
 		time_verbose = "<color=LIGHT>%s</color>持续时间 (<color=LIGHT>%s%%</color>): %s", -- type, percent, time
 		efficiency = "<color=LIGHT>燃烧效率</color>: <color=LIGHT>%s%%</color>",
-		units = "<color=LIGHT>燃料</color>: <color=LIGHT>%s</color>"
+		units = "<color=LIGHT>燃料</color>: <color=LIGHT>%s</color>",
 	},
 
 	-- growable.lua
@@ -413,13 +413,13 @@ return {
 	-- harvestable.lua
 	harvestable = {
 		product = "%s: %s / %s",
-		grow = "%s后+1"
+		grow = "%s后+1",
 	},
 
 	-- hatchable.lua
 	hatchable = {
 		discomfort = "不适感: %s / %s",
-		progress = "孵化过程: %s / %s"
+		progress = "孵化过程: %s / %s",
 	},
 
 	-- healer.lua
@@ -444,7 +444,7 @@ return {
 	hunter = {
 		hunt_progress = "脚印: %s / %s",
 		impending_ambush = "下一个脚印为猎物。",
-		alternate_beast_chance = "<color=#b51212>%s%% 几率</color>是一只<color=MOB_SPAWN>座狼</color>或<color=MOB_SPAWN>钢羊</color>."
+		alternate_beast_chance = "<color=#b51212>%s%% 几率</color>是一只<color=MOB_SPAWN>座狼</color>或<color=MOB_SPAWN>钢羊</color>.",
 	},
 
 	-- hutch_fishbowl.lua [Prefab]
@@ -469,7 +469,7 @@ return {
 
 	-- lureplant.lua [Prefab]
 	lureplant = {
-		become_active = "%s后开始活动"
+		become_active = "%s后开始活动",
 	},
 
 	-- madsciencelab.lua
@@ -491,7 +491,7 @@ return {
 		active = "每 %s 秒检查一次触发器",
 		inactive = "不检查触发器",
 		beemine_bees = "将飞出 %s 个蜜蜂",
-		trap_starfish_cooldown = "%s后重组"
+		trap_starfish_cooldown = "%s后重组",
 	},
 
 	-- moisture.lua
@@ -502,9 +502,9 @@ return {
 		wagstaff_hunt = {
 			progress = "目的地进度: %s / %s",
 			time_for_next_tool = "%s后需要另一个工具",
-			experiment_time = "%s后实验完成"
+			experiment_time = "%s后实验完成",
 		},
-		storm_move = "%s%% 几率于第 %d 天月球风暴。"
+		storm_move = "%s%% 几率于第 %d 天月球风暴。",
 	},
 
 	-- nightmareclock.lua
@@ -527,7 +527,7 @@ return {
 		starves = "饿死",
 		transition = "$2后<color=MONSTER>$1</color>", -- This is correct
 		transition_extended = "$2后<color=MONSTER>$1</color> (<color=MONSTER>%s%%</color>)",
-		paused = "当前暂停腐烂"
+		paused = "当前暂停腐烂",
 	},
 
 	-- petrifiable.lua
@@ -550,8 +550,8 @@ return {
 	questowner = {
 		pipspook = {
 			toys_remaining = "剩余玩具数: %s",
-			assisted_by = "这个小惊吓正在受到 %s 的帮助。"
-		}
+			assisted_by = "这个小惊吓正在受到 %s 的帮助。",
+		},
 	},
 
 	-- rainometer.lua [Prefab]
@@ -582,23 +582,23 @@ return {
 				[MATERIALS.FOSSIL] = "化石",
 				[MATERIALS.MOON_ALTAR] = "天体祭坛"
 			} or
-			{})
+			{}),
 	},
 
 	-- repairable.lua
 	repairable = {
-		chess = "需要<color=#99635D>齿轮</color>: <color=#99635D>%s</color>"
+		chess = "需要<color=#99635D>齿轮</color>: <color=#99635D>%s</color>",
 	},
 
 	-- rocmanager.lua
 	rocmanager = {
-		cant_spawn = "无法生成。"
+		cant_spawn = "无法生成。",
 	},
 
 	-- saddler.lua
 	saddler = {
 		bonus_damage = "<color=HEALTH>额外伤害</color>: <color=HEALTH>%s</color>",
-		bonus_speed = "<color=DAIRY>额外速度</color>: %s%%"
+		bonus_speed = "<color=DAIRY>额外速度</color>: %s%%",
 	},
 
 	-- sanity.lua
@@ -616,8 +616,8 @@ return {
 			hunger = "66% 几率让<color=HUNGER>饥饿</color>从 <color=HUNGER>-20</color> 上升到 <color=HUNGER>20</color>。",
 			health = "66% 几率让<color=HEALTH>健康</color>从 <color=HEALTH>0</color> 上升到 <color=HEALTH>20</color>。",
 			inventory = "66% 几率增加 20% <color=LIGHT>耐久</color>或<color=MONSTER>新鲜</color>。",
-			summonmonsters = "66% 几率召唤 1-3 个<color=MOB_SPAWN>穴居悬蛛</color>."
-		}
+			summonmonsters = "66% 几率召唤 1-3 个<color=MOB_SPAWN>穴居悬蛛</color>.",
+		},
 	},
 
 	-- shadowsubmissive.lua
@@ -625,8 +625,8 @@ return {
 		shadowcreature = {
 			spawned_for = "生成于 %s。",
 			sanity_reward = "<color=SANITY>理智</color>奖励: <color=SANITY>%s</color>",
-			sanity_reward_split = "<color=SANITY>理智</color>奖励: <color=SANITY>%s</color> / <color=SANITY>%s</color>"
-		}
+			sanity_reward_split = "<color=SANITY>理智</color>奖励: <color=SANITY>%s</color> / <color=SANITY>%s</color>",
+		},
 	},
 
 	-- singable.lua
@@ -638,9 +638,9 @@ return {
 			battlesong_sanityaura = "<color=SANITY>负理智光环</color>效果减少 <color=SANITY>%s%%</color>。",
 			battlesong_fireresistance = "受到的<color=LIGHT>火焰</color>伤害<color=HEALTH>减少 %s%%</color>。", -- need optimization
 			battlesong_instant_taunt = "嘲讽所有战歌范围内附近的敌人。",
-			battlesong_instant_panic = "惊恐附近可惊恐的敌人 %s 秒."
+			battlesong_instant_panic = "惊恐附近可惊恐的敌人 %s 秒.",
 		},
-		cost = "Costs %s inspiration to use."
+		cost = "Costs %s inspiration to use.",
 	},
 
 	-- sinkholespawner.lua
@@ -656,13 +656,13 @@ return {
 	-- spawner.lua
 	spawner = {
 		next = "$2后生成 <color=MOB_SPAWN>$1</color>",
-		child = "生成一个 <color=#ff9999>%s</color>"
+		child = "生成一个 <color=#ff9999>%s</color>",
 	},
 
 	-- stagehand.lua [Prefab]
 	stagehand = {
 		hits_remaining = "剩余<color=#aaaaee>敲击</color>: <color=#aaaaee>%s</color>",
-		time_to_reset = "%s后重置"
+		time_to_reset = "%s后重置",
 	},
 
 	-- stewer.lua
@@ -671,7 +671,7 @@ return {
 		cooktime_remaining = "<color=HUNGER><prefab=%s></color>(<color=HUNGER>%s</color>) 将在 %s 秒后完成。",
 		cooker = "由 <color=%s>%s</color> 烹饪",
 		cooktime_modifier_slower = "烹调食物 <color=#DED15E>%s%%</color> 减慢。",
-		cooktime_modifier_faster = "烹调食物 <color=NATURE>%s%%</color> 加快."
+		cooktime_modifier_faster = "烹调食物 <color=NATURE>%s%%</color> 加快.",
 	},
 
 	-- stickable.lua
@@ -688,7 +688,7 @@ return {
 	-- timer.lua
 	timer = {
 		label = "计时 '%s': %s",
-		paused = "暂停"
+		paused = "暂停",
 	},
 
 	-- tool.lua
@@ -717,7 +717,7 @@ return {
 
 	-- wateryprotection.lua
 	wateryprotection = {
-		wetness = "增加 <color=WET>%s</color> 土壤湿度"
+		wetness = "增加 <color=WET>%s</color> 土壤湿度",
 	},
 
 	-- weapon.lua
@@ -725,7 +725,7 @@ return {
 		normal = "<color=HEALTH>伤害</color>",
 		electric = "<color=WET>(电击)</color> <color=HEALTH>伤害</color>",
 		poisonous = "<color=NATURE>(毒性)</color> <color=HEALTH>伤害</color>",
-		thorns = "<color=HEALTH>(反弹)</color> <color=HEALTH>伤害</color>"
+		thorns = "<color=HEALTH>(反弹)</color> <color=HEALTH>伤害</color>",
 	},
 	weapon_damage = "%s: <color=HEALTH>%s</color>",
 	attack_range = "范围: %s",
@@ -734,7 +734,7 @@ return {
 	weighable = {
 		weight = "重量: %s (%s%%)",
 		weight_bounded = "重量: %s <= %s (%s) <= %s",
-		owner_name = "主人: %s"
+		owner_name = "主人: %s",
 	},
 
 	-- werebeast.lua
@@ -746,7 +746,7 @@ return {
 	-- winch.lua
 	winch = {
 		not_winch = "这是一个夹夹绞盘组件，但是预设检查失败",
-		sunken_item = "夹夹绞盘底下有一个<color=#66ee66>%s</color>"
+		sunken_item = "夹夹绞盘底下有一个<color=#66ee66>%s</color>",
 	},
 
 	-- winterometer.lua [Prefab]
@@ -757,19 +757,19 @@ return {
 	-- wintertreegiftable.lua
 	wintertreegiftable = {
 		ready = "你已可以打开<color=#DED15E>稀有礼物</color>。",
-		not_ready = "你必须<color=#ffbbbb>等待 %s 天</color>才能再次获得一个<color=#DED15E>稀有礼物</color>."
+		not_ready = "你必须<color=#ffbbbb>等待 %s 天</color>才能再次获得一个<color=#DED15E>稀有礼物</color>.",
 	},
 
 	-- witherable.lua
 	witherable = {
 		delay = "状态变化延迟%s",
 		wither = "%s后枯萎",
-		rejuvenate = "%s后复长"
+		rejuvenate = "%s后复长",
 	},
 
 	-- workable.lua
 	workable = {
-		treeguard_chance = "<color=#636C5C>树精守卫几率</color>: <sub>你</sub> %s%% & <sub>NPC</sub> %s%%"
+		treeguard_chance = "<color=#636C5C>树精守卫几率</color>: <sub>你</sub> %s%% & <sub>NPC</sub> %s%%",
 	},
 
 	-- worldmigrator.lua
@@ -777,18 +777,18 @@ return {
 		disabled = "切换世界已被禁用。",
 		target_shard = "目标世界: %s",
 		received_portal = "传送门: %s",
-		id = "这是 #: %s"
+		id = "这是 #: %s",
 	},
 
 	-- worldsettingstimer.lua
 	worldsettingstimer = {
 		label = "世界计时器 '%s': %s",
-		paused = "已暂停"
+		paused = "已暂停",
 	},
 
 	-- wx78.lua [Prefab]
 	wx78_charge = "剩余充能: %s",
 
 	-- yotb_sewer.lua
-	yotb_sewer = "缝制将完成于 %s"
+	yotb_sewer = "缝制将完成于 %s",
 }

--- a/scripts/language/chinese.lua
+++ b/scripts/language/chinese.lua
@@ -17,8 +17,37 @@ LICENSE in the form of a LICENSE file in the root of the source
 directory. If not, please refer to
 <https://raw.githubusercontent.com/Recex/Licenses/master/SharedSourceLicense/LICENSE.txt>
 ]]
-
 -- Translated by: https://steamcommunity.com/id/interesting28/ and https://steamcommunity.com/id/cloudyyoung
+
+--[[
+	CY notes (rules to keep consistency):
+	1. Not break Chinese characters with space, even color tags. 
+	2. Only break when meeting pucntuations or numbers or player names.
+	3. Remove unneccessary colons to make strings into a natural sentence (reads better). 
+	   If it's field-like then keep the colon, eg. "Sanity: %s" -> "理智： %s".
+	4. If english "Will die in: %s", then chinese "%s后死亡". Notice there should be no space before "后".
+	5. Translate "Sanity" as "理智" instead of "精神" by dst wiki: https://dontstarve.fandom.com/zh/wiki/%E7%90%86%E6%99%BA?variant=zh-cn
+	6. In strings, you can use $1 to represent the first %s in original string, $2 as second %s, and so on. 
+	   Eg. "Regenerating %s in %s" -> "$2后$1重新生长", the first %s is an entity name and the second is the time, 
+	   however in chinese expressions the time usually goes first, the order of %s are changed, 
+	   so use $1 and $2 to have flexible places of %s
+]]
+
+--[[
+	Pull translations directly from DST, as some language mods might overwrite official translations
+	Eg. Officially "stale" woule be 不新鲜 and "Chinese Language Pack" would give it as 陈旧 for a more native expression
+	So Insight would display translation accordingly
+]]
+local STRINGS = GLOBAL.STRINGS
+local function adjectiveToNoun(str)
+	return str:gsub('%的', '')
+end
+
+local beard = STRINGS.UI.COLLECTIONSCREEN.BEARD
+local catcoon = STRINGS.UI.HUD.TROPHYSCALE_PREFAB_OVERRIDE_OWNER.catcoon
+
+-- perishable
+local stale = adjectiveToNoun(STRINGS.UI.HUD.STALE)
 
 return {
 	-- insightservercrash.lua
@@ -28,28 +57,29 @@ return {
 	dragonfly_ready = "准备战斗",
 
 	-- time.lua
-	time_segments = "%s 个时段",
-	time_days = "%s 天, ",
-	time_days_short = "%s 天",
-	time_seconds = "%s 秒",
-	time_minutes = "%s 分, ",
-	time_hours = "%s 小时, ",
+	-- there;s no comma after days, minutes and hours in chinese expressions
+	time_segments = " %s 个时段",
+	time_days = " %s 天",
+	time_days_short = " %s 天",
+	time_seconds = " %s 秒",
+	time_minutes = " %s 分",
+	time_hours = " %s 小时",
 
 	-- meh
 	seasons = {
 		autumn = "秋天",
 		winter = "冬天",
 		spring = "春天",
-		summer = "夏天",
+		summer = "夏天"
 	},
 
 	-------------------------------------------------------------------------------------------------------------------------
-	
+
 	-- alterguardianhat.lua [Prefab]
 	alterguardianhat = {
-		minimum_sanity = "Minimum <color=SANITY>sanity</color> for light: <color=SANITY>%s</color> (<color=SANITY>%s%%</color>)",
-		current_sanity = "Your <color=SANITY>sanity</color> is: <color=SANITY>%s</color> (<color=SANITY>%s%%</color>)",
-		summoned_gestalt_damage = "Summoned <color=ENLIGHTENMENT>gestalts</color> deal <color=HEALTH>%s</color> damage.",
+		minimum_sanity = "最低<color=SANITY>理智</color>光源: <color=SANITY>%s</color> (<color=SANITY>%s%%</color>)",
+		current_sanity = "你的<color=SANITY>理智</color>: <color=SANITY>%s</color> (<color=SANITY>%s%%</color>)",
+		summoned_gestalt_damage = "召唤<color=ENLIGHTENMENT>月灵</color>造成<color=HEALTH>%s</color>伤害"
 	},
 
 	-- appeasement.lua
@@ -57,19 +87,18 @@ return {
 	appease_bad = "加速火山喷发 %s 个时段",
 
 	-- appraisable.lua
-	appraisable = "Fearsome: %s, Festive: %s, Formal: %s",
+	appraisable = "凶猛: %s, 喜庆: %s, 正式: %s",
 
 	-- archive_lockbox.lua [Prefab]
 	archive_lockbox_unlocks = "解锁: <prefab=%s>",
 
 	-- armor.lua
-	protection = "<color=HEALTH>保护程度</color>: <color=HEALTH>%s%%</color>",
+	protection = "<color=HEALTH>保护度</color>: <color=HEALTH>%s%%</color>",
 	durability = "<color=#C0C0C0>耐久度</color>: <color=#C0C0C0>%s</color> / <color=#C0C0C0>%s</color>",
 	durability_unwrappable = "<color=#C0C0C0>耐久度</color>: <color=#C0C0C0>%s</color>",
 
 	-- beard.lua
-	beard = "你的胡子将在 %s 天后长好.",
-
+	beard = "你的" .. beard .. "将于 %s 天后长好", -- "胡须"
 	-- beargerspawner.lua
 	incoming_bearger_targeted = "<color=%s>目标: %s</color> -> %s",
 
@@ -78,33 +107,34 @@ return {
 
 	-- breeder.lua
 	breeder_tropical_fish = "<color=#64B08C>热带鱼</color>",
+
 	--breeder_fish2 = "Tropical Wanda", --in code but unused
 	breeder_fish3 = "<color=#6C5186>紫石斑鱼</color>",
 	breeder_fish4 = "<color=#DED15E>小丑鱼</color>",
 	breeder_fish5 = "<color=#9ADFDE>霓虹鱼</color>",
 	breeder_fishstring = "%s: %s / %s",
-	breeder_nextfishtime = "加鱼在: %s后", -- cy "额外的鱼: %s", but GT says latter is "extra fish" while former is "add fish". 
-	breeder_possiblepredatortime = "可能生成捕食者: %s",
+	breeder_nextfishtime = "%s后有新鱼", -- cy "额外的鱼: %s", but GT says latter is "extra fish" while former is "add fish".
+	breeder_possiblepredatortime = "可能于%s后生成捕食者",
 
 	-- burnable.lua
 	burnable = {
 		smolder_time = "即将<color=LIGHT>燃起</color>: <color=LIGHT>%s</color>",
-		burn_time = "剩余<color=LIGHT>燃烧时间</color>: <color=LIGHT>%s</color>",
+		burn_time = "剩余<color=LIGHT>燃烧时间</color>: <color=LIGHT>%s</color>"
 	},
-	
+
 	-- canary.lua [Prefab]
 	canary = {
-		gas_level = "<color=#DBC033>Gas level</color>: %s / %s", -- canary, max saturation canary
-		poison_chance = "Chance of becoming <color=#522E61>poisoned</color>: <color=#D8B400>%d%%</color>",
-		gas_level_increase = "Increases in %s.",
-		gas_level_decrease = "Decreases in %s."
+		gas_level = "<color=#DBC033>空气等级</color>: %s / %s", -- canary, max saturation canary
+		poison_chance = "变为<color=#522E61>有毒</color>几率: <color=#D8B400>%d%%</color>",
+		gas_level_increase = "增加于 %s",
+		gas_level_decrease = "减少于 %s"
 	},
 
 	-- catcoonden.lua [Prefab]
 	catcoonden = {
-		lives = "浣熊猫寿命: %s / %s",
-		regenerate = "浣熊猫将复活于: %s",
-		waiting_for_sleep = "等待附近的玩家走开.",
+		lives = catcoon .. "寿命: %s / %s",
+		regenerate = catcoon .. "%s后复活",
+		waiting_for_sleep = "等待附近的玩家走开."
 	},
 
 	-- chessnavy.lua
@@ -112,15 +142,15 @@ return {
 	chessnavy_ready = "等待你回到犯罪地点",
 
 	-- chester_eyebone.lua [Prefab]
-	chester_respawn = "<color=MOB_SPAWN><prefab=chester></color> will respawn in: %s",
+	chester_respawn = "%s后<color=MOB_SPAWN><prefab=chester></color>将生成",
 
 	-- childspawner.lua
 	childspawner = {
 		children = "<color=MOB_SPAWN><prefab=%s></color>: %s<sub>in</sub> + %s<sub>out</sub> / %s",
 		emergency_children = "*<color=MOB_SPAWN><prefab=%s></color>: %s<sub>in</sub> + %s<sub>out</sub> / %s",
 		both_regen = "<color=MOB_SPAWN><prefab=%s></color> & <color=MOB_SPAWN><prefab=%s></color>",
-		regenerating = "%s 重新生长于: %s",
-		entity = "<color=MOB_SPAWN><prefab=%s></color>",
+		regenerating = "$2后$1重新生长",
+		entity = "<color=MOB_SPAWN><prefab=%s></color>"
 	},
 
 	-- combat.lua
@@ -128,9 +158,7 @@ return {
 	damageToYou = " (对你的伤害 <color=HEALTH>%s</color>)",
 
 	-- container.lua
-	container = {
-		
-	},
+	container = {},
 
 	-- cooldown.lua
 	cooldown = "冷却: %s",
@@ -142,7 +170,7 @@ return {
 	dominant_trait = "特质: %s",
 
 	-- crop.lua
-	crop_paused = "暂停",
+	crop_paused = "暂停生长",
 	growth = "<color=NATURE><prefab=%s></color>: <color=NATURE>%s</color>",
 
 	-- dapperness.lua
@@ -150,41 +178,40 @@ return {
 
 	-- debuffable.lua
 	buff_text = "<color=MAGIC>加成</color>: <color=MAGIC>%s</color>, %s",
-	debuffs = { -- ugh
-		["buff_attack"] = "攻击加强 <color=HEALTH>%s%%</color>, 持续 %s 秒.",
-		["buff_playerabsorption"] = "伤害减少 <color=MEAT>%s%%</color>, 持续 %s 秒.",
-		["buff_workeffectiveness"] = "效率提升 <color=#DED15E>%s%%</color>, 持续 %s 秒.",
-
-		["buff_moistureimmunity"] = "免疫 <color=WET>潮湿</color>, 持续 %s 秒.",
-		["buff_electricattack"] = "攻击 <color=WET>带电</color>, 持续 %s 秒.",
-		["buff_sleepresistance"] = "抵抗 <color=MONSTER>睡眠</color>, 持续 %s 秒.",
-		
-		["tillweedsalve_buff"] = "回复 <color=HEALTH>%s 健康</color> 于 %s 秒内.",
-		["healthregenbuff"] = "回复 <color=HEALTH>%s 健康</color> 于 %s 秒内.",
-		["sweettea_buff"] = "回复 <color=SANITY>%s 精神</color> 于 %s 秒内.",
+	debuffs = {
+		-- ugh
+		["buff_attack"] = "攻击加强 <color=HEALTH>%s%%</color>, 持续 %s 秒。",
+		["buff_playerabsorption"] = "伤害减少 <color=MEAT>%s%%</color>, 持续 %s 秒。",
+		["buff_workeffectiveness"] = "效率提升 <color=#DED15E>%s%%</color>, 持续 %s 秒。",
+		["buff_moistureimmunity"] = "免疫<color=WET>潮湿</color>, 持续 %s 秒。",
+		["buff_electricattack"] = "攻击<color=WET>带电</color>, 持续 %s 秒。",
+		["buff_sleepresistance"] = "抵抗<color=MONSTER>睡眠</color>, 持续 %s 秒。",
+		["tillweedsalve_buff"] = "$2 秒内回复 <color=HEALTH>$1 健康</color>。",
+		["healthregenbuff"] = "$2 秒内回复 <color=HEALTH>$1 健康</color>。",
+		["sweettea_buff"] = "$2 秒内回复 <color=SANITY>$1 理智</color>。"
 	},
 
 	-- deerclopsspawner.lua
 	incoming_deerclops_targeted = "<color=%s>目标: %s</color> -> %s",
 
 	-- diseaseable.lua
-	disease_in = "将感染疾病于: %s",
-	disease_spread = "将传播疾病于: %s",
-	disease_delay = "疾病被延迟: %s",
+	disease_in = "将于%s后感染疾病",
+	disease_spread = "将于%s后传播疾病",
+	disease_delay = "疾病被延迟%s",
 
 	-- domesticatable.lua
 	domesticatable = {
-		domestication = "驯化值: %s%%",
-		obedience = "顺从值: %s%%",
-		obedience_extended = "Obedience: %s%% (Saddle: >=%s%%, Keep Saddle: >%s%%, Lose Domestication: <=%s%%)",
-		tendency = "趋势: %s",
+		domestication = "驯化: %s%%",
+		obedience = "顺从: %s%%",
+		obedience_extended = "顺从: %s%% (鞍具: >=%s%%, 保持鞍具: >%s%%, 失去驯化: <=%s%%)",
+		tendency = "倾向: %s",
 		tendencies = {
-			["NONE"] = "None",
-			[TENDENCY.DEFAULT] = "Default",
-			[TENDENCY.ORNERY] = "Ornery",
-			[TENDENCY.RIDER] = "Rider",
-			[TENDENCY.PUDGY] = "Pudgy"
-		},
+			["NONE"] = "无",
+			[TENDENCY.DEFAULT] = "默认",
+			[TENDENCY.ORNERY] = "战斗",
+			[TENDENCY.RIDER] = "骑乘",
+			[TENDENCY.PUDGY] = "肥胖"
+		}
 	},
 
 	-- drivable.lua
@@ -194,7 +221,7 @@ return {
 	dry_time = "完成还需: %s",
 
 	-- edible.lua
-	food_unit = "<color=%s>%s</color> 个单位的 <color=%s>%s</color>",
+	food_unit = "<color=%s>%s</color> 个单位的<color=%s>%s</color>",
 	edible_interface = "<color=HUNGER>饥饿</color>: <color=HUNGER>%s</color> / <color=SANITY>理智</color>: <color=SANITY>%s</color> / <color=HEALTH>生命</color>: <color=HEALTH>%s</color>",
 	edible_wiki = "<color=HEALTH>生命</color>: <color=HEALTH>%s</color> / <color=HUNGER>饥饿</color>: <color=HUNGER>%s</color> / <color=SANITY>理智</color>: <color=SANITY>%s</color>",
 	edible_foodtype = {
@@ -222,17 +249,17 @@ return {
 		surf = "船只速度: %s, %s",
 		autodry = "干燥: %s, %s",
 		instant_temperature = "温度变化: %s, (瞬间)",
-		antihistamine = "花粉症延时: %ss",
+		antihistamine = "花粉症延时: %ss"
 	},
-	foodmemory = "最近食用: %s / %s，会忘记于: %s后",
-	wereeater = "已食用<color=MONSTER>怪兽肉</color>: %s / %s, 将消逝于: %s", 
+	foodmemory = "最近食用: %s / %s，将忘记于%s后",
+	wereeater = "已食用<color=MONSTER>怪兽肉</color>: %s / %s, 将消逝于%s后",
 
 	-- equippable.lua
 	-- use 'dapperness' from 'dapperness'
 	speed = "<color=DAIRY>移动速度</color>: %s%%",
 	hunger_slow = "<color=HUNGER>饥饿速度降低</color>: <color=HUNGER>%s%%</color>",
 	hunger_drain = "<color=HUNGER>饥饿度降低</color>: <color=HUNGER>%s%%</color>",
-	insulated = "保护你免遭雷击.",
+	insulated = "保护你免遭雷击。",
 
 	-- example.lua
 	why = "[为什么我是空的]",
@@ -243,54 +270,57 @@ return {
 
 	-- farmplantable.lua
 	farmplantable = {
-		product = "会长成 <color=NATURE><prefab=%s></color>.",
-		nutrient_consumption = "植物消耗: [<color=NATURE>%d<sub>施法</sub></color>, <color=CAMO>%d<sub>肥料</sub></color>, <color=INEDIBLE>%d<sub>便便</sub></color>]",
-		good_seasons = "生长季节: %s",
+		product = "将长成 <color=NATURE><prefab=%s></color>。",
+		nutrient_consumption = "消耗养分: [<color=NATURE>%d<sub>催长剂</sub></color>, <color=CAMO>%d<sub>堆肥</sub></color>, <color=INEDIBLE>%d<sub>粪肥</sub></color>]",
+		good_seasons = "生长季节: %s"
 	},
 
 	-- farmplantstress.lua
 	farmplantstress = {
-		stress_points = "压力点: %s",
-		display = "压力源: %s",
-		stress_tier = "压力等级: %s",
-		tiers = (IsDST() and {
-			[FARM_PLANT_STRESS.NONE] = "无",
-			[FARM_PLANT_STRESS.LOW] = "低",
-			[FARM_PLANT_STRESS.MODERATE] = "中",
-			[FARM_PLANT_STRESS.HIGH] = "高",
-		} or {}),
+		stress_points = "压力值: %s",
+		display = "压力来源: %s",
+		stress_tier = "压力级别: %s",
+		tiers = (IsDST() and
+			{
+				[FARM_PLANT_STRESS.NONE] = "无",
+				[FARM_PLANT_STRESS.LOW] = "低",
+				[FARM_PLANT_STRESS.MODERATE] = "中",
+				[FARM_PLANT_STRESS.HIGH] = "高"
+			} or
+			{})
 	},
 
 	-- farmsoildrinker.lua
 	farmsoildrinker = {
-		soil_only = "<color=WET>Water</color>: <color=WET>%s<sub>tile</sub></color>",
-		soil_plant = "<color=WET>Water</color>: <color=WET>%s<sub>tile</sub></color> (<color=WET>%s/min<sub>plant</sub></color>)",
-		soil_plant_tile = "<color=WET>Water</color>: <color=WET>%s<sub>tile</sub></color> (<color=WET>%s<sub>plant</sub></color> [<color=#2f96c4>%s<sub>tile</sub></color>])<color=WET>/min</color>",
-		soil_plant_tile_net = "<color=WET>Water</color>: <color=WET>%s<sub>tile</sub></color> (<color=WET>%s<sub>plant</sub></color> [<color=#2f96c4>%s<sub>tile</sub></color> + <color=SHALLOWS>%s<sub>world</sub></color> = <color=#DED15E>%+.1f<sub>net</sub></color>])<color=WET>/min</color>"
+		soil_only = "<color=WET>水分</color>: <color=WET>%s<sub> 格</sub></color>",
+		soil_plant = "<color=WET>水分</color>: <color=WET>%s<sub> 格</sub></color> (<color=WET>%s/分<sub>植物</sub></color>)",
+		soil_plant_tile = "<color=WET>水分</color>: <color=WET>%s<sub> 格</sub></color> (<color=WET>%s<sub>植物</sub></color> [<color=#2f96c4>%s<sub>格</sub></color>])<color=WET>/分</color>",
+		soil_plant_tile_net = "<color=WET>水分</color>: <color=WET>%s<sub> 格</sub></color> (<color=WET>%s<sub>植物</sub></color> [<color=#2f96c4>%s<sub>格</sub></color> + <color=SHALLOWS>%s<sub>世界</sub></color> = <color=#DED15E>%+.1f<sub>网</sub></color>])<color=WET>/分</color>"
 	},
 
+	-- Formula 催长剂, Compost 堆肥, Manure 粪肥 by free translation
 	farmsoildrinker_nutrients = {
-		soil_only = "养分: [<color=NATURE>%+d<sub>法</sub></color>, <color=CAMO>%+d<sub>肥</sub></color>, <color=INEDIBLE>%+d<sub>便</sub></color>]",
-		soil_plant = "养分: [<color=NATURE>%+d<sub>法</sub></color>, <color=CAMO>%+d<sub>肥</sub></color>, <color=INEDIBLE>%+d<sub>便</sub></color>] ([<color=NATURE>%+d<sub>法</sub></color>, <color=CAMO>%+d<sub>肥</sub></color>, <color=INEDIBLE>%+d<sub>便</sub></color>])",
-		--soil_plant_tile = "Nutrients: [%+d<color=NATURE><sub>F</sub></color>, %+d<color=CAMO><sub>C</sub></color>, %+d<color=INEDIBLE><sub>M</sub></color>]<sup>tile</sup> ([<color=#bee391>%+d<sub>F</sub></color>, <color=#7a9c6e>%+d<sub>C</sub></color>, <color=INEDIBLE>%+d<sub>M</sub></color>]<sup>plantΔ</sup>   [<color=NATURE>%+d<sub>F</sub></color>, <color=CAMO>%+d<sub>C</sub></color>, <color=INEDIBLE>%+d<sub>M</sub></color>]<sup>tileΔ</sup>)",
-		--soil_plant_tile = "Nutrients: [%+d<color=NATURE><sub>F</sub></color>, %+d<color=CAMO><sub>C</sub></color>, %+d<color=INEDIBLE><sub>M</sub></color>]<sup>tile</sup> ([<color=NATURE>%+d<sub>F</sub></color>, <color=CAMO>%+d<sub>C</sub></color>, <color=INEDIBLE>%+d<sub>M</sub></color>]<sup>plantΔ</sup>   [<color=NATURE>%+d<sub>F</sub></color>, <color=CAMO>%+d<sub>C</sub></color>, <color=INEDIBLE>%+d<sub>M</sub></color>]<sup>tileΔ</sup>)",
-		soil_plant_tile = "养分: [<color=NATURE>%+d<sub>法</sub></color>, <color=CAMO>%+d<sub>肥</sub></color>, <color=INEDIBLE>%+d<sub>便</sub></color>]<sub>tile</sub>   (Δ[<color=NATURE>%+d<sub>法</sub></color>, <color=CAMO>%+d<sub>肥</sub></color>, <color=INEDIBLE>%+d<sub>便</sub></color>]<sub>植物</sub> [<color=NATURE>%+d<sub>法</sub></color>, <color=CAMO>%+d<sub>肥</sub></color>, <color=INEDIBLE>%+d<sub>便</sub></color>]<sub>Δ格</sub>)",
-		--soil_plant_tile_net = "Nutrients: [<color=NATURE>%+d<sub>F</sub></color>, <color=CAMO>%+d<sub>C</sub></color>, <color=INEDIBLE>%+d<sub>M</sub></color>] ([<color=NATURE>%+d<sub>F</sub></color>, <color=CAMO>%+d<sub>C</sub></color>, <color=INEDIBLE>%+d<sub>M</sub></color>] + [<color=NATURE>%+d<sub>F</sub></color>, <color=CAMO>%+d<sub>C</sub></color>, <color=INEDIBLE>%+d<sub>M</sub></color>] = [<color=NATURE>%+d<sub>F</sub></color>, <color=CAMO>%+d<sub>C</sub></color>, <color=INEDIBLE>%+d<sub>M</sub></color>])"
+		soil_only = "养分: [<color=NATURE>%+d<sub>催</sub></color>, <color=CAMO>%+d<sub>堆</sub></color>, <color=INEDIBLE>%+d<sub>粪</sub></color>]",
+		soil_plant = "养分: [<color=NATURE>%+d<sub>催</sub></color>, <color=CAMO>%+d<sub>堆</sub></color>, <color=INEDIBLE>%+d<sub>粪</sub></color>] ([<color=NATURE>%+d<sub>催</sub></color>, <color=CAMO>%+d<sub>堆</sub></color>, <color=INEDIBLE>%+d<sub>便</sub></color>])",
+		--soil_plant_tile = "养分: [%+d<color=NATURE><sub>催</sub></color>, %+d<color=CAMO><sub>堆</sub></color>, %+d<color=INEDIBLE><sub>粪</sub></color>]<sup>格</sup> ([<color=#bee391>%+d<sub>催</sub></color>, <color=#7a9c6e>%+d<sub>堆</sub></color>, <color=INEDIBLE>%+d<sub>便</sub></color>]<sup>plantΔ</sup>   [<color=NATURE>%+d<sub>催</sub></color>, <color=CAMO>%+d<sub>堆</sub></color>, <color=INEDIBLE>%+d<sub>粪</sub></color>]<sup>格Δ</sup>)",
+		--soil_plant_tile = "养分: [%+d<color=NATURE><sub>催</sub></color>, %+d<color=CAMO><sub>堆</sub></color>, %+d<color=INEDIBLE><sub>粪</sub></color>]<sup>格</sup> ([<color=NATURE>%+d<sub>催</sub></color>, <color=CAMO>%+d<sub>堆</sub></color>, <color=INEDIBLE>%+d<sub>便</sub></color>]<sup>plantΔ</sup>   [<color=NATURE>%+d<sub>催</sub></color>, <color=CAMO>%+d<sub>堆</sub></color>, <color=INEDIBLE>%+d<sub>粪</sub></color>]<sup>格Δ</sup>)",
+		soil_plant_tile = "养分: [<color=NATURE>%+d<sub>催</sub></color>, <color=CAMO>%+d<sub>堆</sub></color>, <color=INEDIBLE>%+d<sub>粪</sub></color>]<sub>tile</sub>   (Δ[<color=NATURE>%+d<sub>催</sub></color>, <color=CAMO>%+d<sub>堆</sub></color>, <color=INEDIBLE>%+d<sub>便</sub></color>]<sub>植物</sub> [<color=NATURE>%+d<sub>催</sub></color>, <color=CAMO>%+d<sub>堆</sub></color>, <color=INEDIBLE>%+d<sub>粪</sub></color>]<sub>格Δ</sub>)"
+		--soil_plant_tile_net = "养分: [<color=NATURE>%+d<sub>催</sub></color>, <color=CAMO>%+d<sub>堆</sub></color>, <color=INEDIBLE>%+d<sub>粪</sub></color>] ([<color=NATURE>%+d<sub>催</sub></color>, <color=CAMO>%+d<sub>堆</sub></color>, <color=INEDIBLE>%+d<sub>便</sub></color>] + [<color=NATURE>%+d<sub>催</sub></color>, <color=CAMO>%+d<sub>堆</sub></color>, <color=INEDIBLE>%+d<sub>粪</sub></color>] = [<color=NATURE>%+d<sub>催</sub></color>, <color=CAMO>%+d<sub>堆</sub></color>, <color=INEDIBLE>%+d<sub>粪</sub></color>])"
 	},
-	
+
 	-- fertilizer.lua
 	fertilizer = {
 		growth_value = "缩短 <color=NATURE>%s</color> 秒<color=NATURE>生长时间</color>",
-		nutrient_value = "养分: [<color=NATURE>%s</color>, <color=CAMO>%s</color>, <color=INEDIBLE>%s</color>]",
+		nutrient_value = "养分: [<color=NATURE>%s<sub>催长剂</sub></color>, <color=CAMO>%s<sub>堆肥</sub></color>, <color=INEDIBLE>%s<sub>粪肥</sub></color>]",
 		wormwood = {
-			formula_growth = "加速<color=LIGHT_PINK>开花</color> <color=LIGHT_PINK>%s</color>.",
-			compost_heal = "<color=HEALTH>回复</color> 你 <color=HEALTH>%+d</color> 于 <color=HEALTH>%s</color> 秒.",
-		},
+			formula_growth = "你的<color=LIGHT_PINK>开花</color>加速 <color=LIGHT_PINK>%s</color>。",
+			compost_heal = "<color=HEALTH>回复</color> <color=HEALTH>$2</color> 秒你的<color=HEALTH>$1</color>。"
+		}
 	},
 
 	-- fillable.lua
 	fillable = {
-		accepts_ocean_water = "能被海水填充",
+		accepts_ocean_water = "可被海水填充"
 	},
 
 	-- finiteuses.lua
@@ -321,24 +351,24 @@ return {
 		fish = "钓",
 		row = "划",
 		row_fail = "划（失败）",
-		till = "耕种",
+		till = "耕种"
 	},
 
 	-- fishable.lua
 	fish_count = "<color=SHALLOWS>鱼</color>: <color=WET>%s</color> / <color=WET>%s</color>",
-	fish_recharge = "+1 条鱼于: %s",
-	--fish_wait_time = "Will take <color=SHALLOWS>%s seconds</color> to catch a fish.",
+	fish_recharge = "%s后增加一条鱼",
+
+	--fish_wait_time = "抓一条鱼将花费 <color=SHALLOWS>%s 秒</color>。",
 
 	-- fishingrod.lua
 	fishingrod_waittimes = "等待时间: <color=SHALLOWS>%s</color> - <color=SHALLOWS>%s</color>",
 	fishingrod_loserodtime = "最大缠绕时间: <color=SHALLOWS>%s</color>",
 
 	-- follower.lua
-	leader = "领导者: %s", -- cy "主人: %s", but GT says it comes out to "the host"
-	loyalty_duration = "忠臣持续时间: %s",
-	ghostlybond = "等级: %s / %s. +1在%s后",
-	ghostlybond_self = "你的等级: %s / %s. +1在%s后", -- i did this one myself ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
+	leader = "主人: %s", -- "主人" should mean "master" here by free translation, "领导者" is literal translation and not precise?
+	loyalty_duration = "忠诚持续时间: %s",
+	ghostlybond = "等级: %s / %s, %s后升级", -- Originally "+1 in: %s", by free translation meaning "Upgrade in %s after"
+	ghostlybond_self = "你的等级: %s / %s, %s后升级", -- i did this one myself ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	-- forcecompostable.lua
 	forcecompostable = "肥料值: %s",
 
@@ -347,7 +377,7 @@ return {
 		pieces_needed = "有 20%% 几率组装错误在组装上 %s 片后",
 		correct = "组装正确",
 		incorrect = "组装错误",
-		gateway_too_far = "This skeleton is %s tile(s) too far.",
+		gateway_too_far = "这个骷髅距离是 %s 个格子"
 	},
 
 	-- friendlevels.lua
@@ -355,23 +385,23 @@ return {
 
 	-- fuel.lua
 	fuel = {
-		fuel = "<color=LIGHT>%s</color> 秒的燃料.",
-		fuel_verbose = "<color=LIGHT>%s</color> 秒的 <color=LIGHT>%s</color>",
-		type = "燃料类型: %s",
+		fuel = "<color=LIGHT>%s</color> 秒的燃料",
+		fuel_verbose = "<color=LIGHT>%s</color> 秒的<color=LIGHT>%s</color>",
+		type = "燃料类型: %s"
 	},
 
 	-- fueled.lua
 	fueled = {
-		time = "<color=LIGHT>燃料</color> 持续时间 (<color=LIGHT>%s%%</color>): %s", -- percent, time
-		time_verbose = "<color=LIGHT>%s</color> 持续时间 (<color=LIGHT>%s%%</color>): %s", -- type, percent, time
+		time = "<color=LIGHT>燃料</color>持续时间 (<color=LIGHT>%s%%</color>): %s", -- percent, time
+		time_verbose = "<color=LIGHT>%s</color>持续时间 (<color=LIGHT>%s%%</color>): %s", -- type, percent, time
 		efficiency = "<color=LIGHT>燃烧效率</color>: <color=LIGHT>%s%%</color>",
-		units = "<color=LIGHT>燃料</color>: <color=LIGHT>%s</color>",
+		units = "<color=LIGHT>燃料</color>: <color=LIGHT>%s</color>"
 	},
 
 	-- growable.lua
-	growth_stage = "阶段 '%s': %s / %s: ",
+	growth_stage = "'%s' 阶段: %s / %s: ",
 	growth_paused = "暂停生长",
-	growth_next_stage = "下一阶段在%s 后",
+	growth_next_stage = "%s后进入下一阶段",
 
 	-- grower.lua
 	harvests = "<color=NATURE>剩余使用次数</color>: <color=NATURE>%s</color> / <color=NATURE>%s</color>",
@@ -383,13 +413,13 @@ return {
 	-- harvestable.lua
 	harvestable = {
 		product = "%s: %s / %s",
-		grow = "+1 于 %s后",
+		grow = "%s后+1"
 	},
 
 	-- hatchable.lua
 	hatchable = {
-		discomfort = "不舒适感: %s / %s",
-		progress = "孵化过程: %s / %s",
+		discomfort = "不适感: %s / %s",
+		progress = "孵化过程: %s / %s"
 	},
 
 	-- healer.lua
@@ -412,42 +442,42 @@ return {
 
 	-- hunter.lua
 	hunter = {
-		hunt_progress = "追踪: %s / %s",
-		impending_ambush = "There is an ambush waiting on the next track.",
-		alternate_beast_chance = "<color=#b51212>%s%% chance</color> for a <color=MOB_SPAWN>Varg</color> or <color=MOB_SPAWN>Ewecus</color>.",
+		hunt_progress = "脚印: %s / %s",
+		impending_ambush = "下一个脚印为猎物。",
+		alternate_beast_chance = "<color=#b51212>%s%% 几率</color>是一只<color=MOB_SPAWN>座狼</color>或<color=MOB_SPAWN>钢羊</color>."
 	},
 
 	-- hutch_fishbowl.lua [Prefab]
-	hutch_respawn = "<color=MOB_SPAWN><prefab=hutch></color> will respawn in: %s",
+	hutch_respawn = "%s后将生成<color=MOB_SPAWN><prefab=hutch></color>",
 
 	-- inspectable.lua
 	wagstaff_tool = "The name of this tool is: <prefab=%s>",
-	
+
 	-- insulator.lua
 	insulation_winter = "<color=FROZEN>保暖效果</color>: <color=FROZEN>%s</color>",
 	insulation_summer = "<color=FROZEN>隔热效果</color>: <color=FROZEN>%s</color>",
 
 	-- klaussackloot.lua
-	klaussackloot = "Notable loot:",
+	klaussackloot = "重要战利品:",
 
 	-- klaussackspawner.lua
 	klaussack_spawnsin = "%s",
-	klaussack_despawn = "消失在第 %s 天",
+	klaussack_despawn = "消失于第 %s 天",
 
 	-- leader.lua
 	followers = "跟随者数量: %s",
 
 	-- lureplant.lua [Prefab]
 	lureplant = {
-		become_active = "开始活动于: %s后",
+		become_active = "%s后开始活动"
 	},
 
 	-- madsciencelab.lua
-	madsciencelab_finish = "完成于: %s后",
+	madsciencelab_finish = "%s后完成",
 
 	-- malbatrossspawner.lua
 	malbatross_spawnsin = "%s",
-	malbatross_waiting = "等待某人去到鱼群",
+	malbatross_waiting = "等待某人前往鱼群",
 
 	-- mast.lua
 	mast_sail_force = "帆力: %s",
@@ -458,28 +488,28 @@ return {
 
 	-- mine.lua
 	mine = {
-		active = "Checks for triggers every %s second(s).",
-		inactive = "Not checking for triggers.",
-		beemine_bees = "Will release %s bee(s).",
-		trap_starfish_cooldown = "重组于: %s后",
+		active = "每 %s 秒检查一次触发器",
+		inactive = "不检查触发器",
+		beemine_bees = "将飞出 %s 个蜜蜂",
+		trap_starfish_cooldown = "%s后重组"
 	},
 
 	-- moisture.lua
-	moisture = "<color=WET>潮湿度</color>: <color=WET>%s%%</color>",
+	moisture = "<color=WET>潮湿</color>: <color=WET>%s%%</color>",
 
 	-- moonstormmanager.lua
 	moonstormmanager = {
 		wagstaff_hunt = {
-			progress = "Progress to destination: %s / %s",
-			time_for_next_tool = "Will need another tool in %s.",
-			experiment_time = "Experiment will complete in %s.",
+			progress = "目的地进度: %s / %s",
+			time_for_next_tool = "%s后需要另一个工具",
+			experiment_time = "%s后实验完成"
 		},
-		storm_move = "%s%% chance to move moonstorms on day %s.",
+		storm_move = "%s%% 几率于第 %d 天月球风暴。"
 	},
 
 	-- nightmareclock.lua
-	nightmareclock = "<color=%s>阶段: %s</color>, %s", -- weird one, 时期 VS 阶段?
-	nightmareclock_lock = "被<color=#CE3D45>远古钥匙</color>锁住",
+	nightmareclock = "<color=%s>阶段: %s</color>, %s", -- "阶段 Stage" by free translation, same term used in dst wiki
+	nightmareclock_lock = "被<color=#CE3D45>远古钥匙</color>锁住。",
 
 	-- oar.lua
 	oar_force = "<color=INEDIBLE>力度</color>: <color=INEDIBLE>%s%%</color>",
@@ -491,20 +521,20 @@ return {
 	-- perishable.lua
 	perishable = {
 		rot = "腐烂",
-		stale = "不新鲜", -- cy: "陈旧", GT says "obsolete"
+		stale = stale, -- cy: "陈旧", GT says "obsolete"
 		spoil = "变质",
 		dies = "死亡",
 		starves = "饿死",
-		transition = "<color=MONSTER>%s</color>于: %s后", -- cy: for this and extended, remove "后", but GT says right now its "after" and removing makes it "on"
-		transition_extended = "<color=MONSTER>%s</color>于: %s后 (<color=MONSTER>%s%%</color>)",
-		paused = "当前暂停腐烂",
+		transition = "$2后<color=MONSTER>$1</color>", -- This is correct
+		transition_extended = "$2后<color=MONSTER>$1</color> (<color=MONSTER>%s%%</color>)",
+		paused = "当前暂停腐烂"
 	},
 
 	-- petrifiable.lua
-	petrify = "石化于: %s",
+	petrify = "%s后石化",
 
 	-- pickable.lua
-	regrowth = "<color=NATURE>重新生长</color> 在: <color=NATURE>%s</color> 后", -- has grammar problem, left because too annoying
+	regrowth = "<color=NATURE>重新生长</color>于 <color=NATURE>%s</color>后", -- has grammar problem, left because too annoying
 	regrowth_paused = "重生暂停",
 	pickable_cycles = "剩余收获次数: %s / %s",
 
@@ -512,17 +542,16 @@ return {
 	pollination = "花朵授粉: (%s) / %s",
 
 	-- preservative.lua
-	preservative = "恢复 %s%% 新鲜度.",
+	preservative = "恢复 %s%% 新鲜度。",
 
 	-- quaker.lua
-	next_quake = "<color=INEDIBLE>地震</color> 于%s后", -- same thing as perishable transition
-
+	next_quake = "%s后<color=INEDIBLE>地震</color>", -- same thing as perishable transition
 	-- questowner.lua
 	questowner = {
 		pipspook = {
 			toys_remaining = "剩余玩具数: %s",
-			assisted_by = "这个小惊吓正在受到 %s 的帮助",
-		},
+			assisted_by = "这个小惊吓正在受到 %s 的帮助。"
+		}
 	},
 
 	-- rainometer.lua [Prefab]
@@ -535,112 +564,114 @@ return {
 		type = "修复工具: <color=#aaaaaa>%s</color>",
 		health = "<color=HEALTH>生命恢复</color>: <color=HEALTH>%s</color> + <color=HEALTH>%s%%</color>",
 		health2 = "<color=HEALTH>%s<sub>flat HP</sub></color> + <color=HEALTH>%s%%<sub>percent HP</sub></color>",
-		work = "<color=#DED15E>Work repair</color>: <color=#DED15E>%s</color>",
+		work = "<color=#DED15E>工作修复</color>: <color=#DED15E>%s</color>",
 		work2 = "<color=#DED15E>%s<sub>work</sub></color>",
 		perish = "<color=MONSTER>提鲜</color>: <color=MONSTER>%s%%</color>",
 		perish2 = "<color=MONSTER>提鲜</color>: <color=MONSTER>%s%%</color>",
-		materials = (IsDST() and {
-			[MATERIALS.WOOD] =  "木头",
-			[MATERIALS.STONE] =  "石头",
-			[MATERIALS.HAY] =  "干草",
-			[MATERIALS.THULECITE] =  "图勒信物",
-			[MATERIALS.GEM] =  "宝石",
-			[MATERIALS.GEARS] =  "齿轮",
-			[MATERIALS.MOONROCK] =  "月岩石",
-			[MATERIALS.ICE] =  "冰",
-			[MATERIALS.SCULPTURE] =  "雕像",
-			[MATERIALS.FOSSIL] =  "化石",
-			[MATERIALS.MOON_ALTAR] =  "天体祭坛",
-		} or {}),
+		materials = (IsDST() and
+			{
+				[MATERIALS.WOOD] = "木头",
+				[MATERIALS.STONE] = "石头",
+				[MATERIALS.HAY] = "干草",
+				[MATERIALS.THULECITE] = "图勒信物",
+				[MATERIALS.GEM] = "宝石",
+				[MATERIALS.GEARS] = "齿轮",
+				[MATERIALS.MOONROCK] = "月岩石",
+				[MATERIALS.ICE] = "冰",
+				[MATERIALS.SCULPTURE] = "雕像",
+				[MATERIALS.FOSSIL] = "化石",
+				[MATERIALS.MOON_ALTAR] = "天体祭坛"
+			} or
+			{})
 	},
 
 	-- repairable.lua
 	repairable = {
-		chess = "需要<color=#99635D>齿轮</color>: <color=#99635D>%s</color>",
+		chess = "需要<color=#99635D>齿轮</color>: <color=#99635D>%s</color>"
 	},
 
 	-- rocmanager.lua
 	rocmanager = {
-		cant_spawn = "无法生成"
+		cant_spawn = "无法生成。"
 	},
 
 	-- saddler.lua
 	saddler = {
-		bonus_damage = "<color=HEALTH>Bonus damage</color>: <color=HEALTH>%s</color>",
-		bonus_speed = "<color=DAIRY>Bonus speed</color>: %s%%",
+		bonus_damage = "<color=HEALTH>额外伤害</color>: <color=HEALTH>%s</color>",
+		bonus_speed = "<color=DAIRY>额外速度</color>: %s%%"
 	},
 
 	-- sanity.lua
 	sanity = "<color=SANITY>理智</color>: <color=SANITY>%s</color> / <color=SANITY>%s</color> (<color=SANITY>%s%%</color>)",
-	enlightenment = "<color=ENLIGHTENMENT>启蒙值</color>: <color=ENLIGHTENMENT>%s</color> / <color=ENLIGHTENMENT>%s</color> (<color=ENLIGHTENMENT>%s%%</color>)",
+	enlightenment = "<color=ENLIGHTENMENT>启蒙</color>: <color=ENLIGHTENMENT>%s</color> / <color=ENLIGHTENMENT>%s</color> (<color=ENLIGHTENMENT>%s%%</color>)",
 
 	-- sanityaura.lua
 	sanityaura = "<color=SANITY>理智光环</color>: <color=SANITY>%s/分</color>",
 
 	-- scenariorunner.lua
 	scenariorunner = {
-		opened_already = "This has been opened already.",
+		opened_already = "这个已经打开过了",
 		chest_labyrinth = {
-			sanity = "66% chance to change <color=SANITY>sanity</color> by <color=SANITY>-20</color> to <color=SANITY>20</color>.",
-			hunger = "66% chance to change <color=HUNGER>hunger</color> by <color=HUNGER>-20</color> to <color=HUNGER>20</color>.",
-			health = "66% chance to change <color=HEALTH>health</color> by <color=HEALTH>0</color> to <color=HEALTH>20</color>.",
-			inventory = "66% chance to change <color=LIGHT>durability</color> or <color=MONSTER>freshness</color> by 20%.",
-			summonmonsters = "66% chance to summon 1-3 <color=MOB_SPAWN>Depth Dwellers</color>.",
-		},
+			sanity = "66% 几率让<color=SANITY>理智</color>从 <color=SANITY>-20</color> 上升到 <color=SANITY>20</color>。",
+			hunger = "66% 几率让<color=HUNGER>饥饿</color>从 <color=HUNGER>-20</color> 上升到 <color=HUNGER>20</color>。",
+			health = "66% 几率让<color=HEALTH>健康</color>从 <color=HEALTH>0</color> 上升到 <color=HEALTH>20</color>。",
+			inventory = "66% 几率增加 20% <color=LIGHT>耐久</color>或<color=MONSTER>新鲜</color>。",
+			summonmonsters = "66% 几率召唤 1-3 个<color=MOB_SPAWN>穴居悬蛛</color>."
+		}
 	},
 
 	-- shadowsubmissive.lua
 	shadowsubmissive = {
 		shadowcreature = {
-			spawned_for = "Spawned by %s.",
-			sanity_reward = "<color=SANITY>Sanity</color> reward: <color=SANITY>%s</color>",
-			sanity_reward_split = "<color=SANITY>Sanity</color> reward: <color=SANITY>%s</color> / <color=SANITY>%s</color>",
-		},
+			spawned_for = "生成于 %s。",
+			sanity_reward = "<color=SANITY>理智</color>奖励: <color=SANITY>%s</color>",
+			sanity_reward_split = "<color=SANITY>理智</color>奖励: <color=SANITY>%s</color> / <color=SANITY>%s</color>"
+		}
 	},
 
 	-- singable.lua
 	singable = {
 		battlesong = {
-			battlesong_durability = "<color=HEALTH>Weapons</color> last <color=#aaaaee>%s%%</color> longer.",
-			battlesong_healthgain = "Hitting enemies restores <color=HEALTH>%s health</color> (<color=HEALTH>%s</color> for Wigfrids).",
-			battlesong_sanitygain = "Hitting enemies restores <color=SANITY>%s sanity</color>.",
-			battlesong_sanityaura = "Negative <color=SANITY>sanity auras</color> are <color=SANITY>%s%%</color> less effective.",
-			battlesong_fireresistance = "Take <color=HEALTH>%s%% less damage</color> from <color=LIGHT>fire</color>.",
-			battlesong_instant_taunt = "Taunts all nearby enemies within song radius.",
-			battlesong_instant_panic = "Panics nearby hauntable enemies for %s second(s).",
+			battlesong_durability = "<color=HEALTH>武器</color>持续时间增加 <color=#aaaaee>%s%%</color>。",
+			battlesong_healthgain = "攻击敌人回复 <color=HEALTH>%s 生命</color> (薇格弗德为 <color=HEALTH>%s</color>)。",
+			battlesong_sanitygain = "攻击敌人回复 <color=SANITY>%s 理智</color>。",
+			battlesong_sanityaura = "<color=SANITY>负理智光环</color>效果减少 <color=SANITY>%s%%</color>。",
+			battlesong_fireresistance = "受到的<color=LIGHT>火焰</color>伤害<color=HEALTH>减少 %s%%</color>。", -- need optimization
+			battlesong_instant_taunt = "嘲讽所有战歌范围内附近的敌人。",
+			battlesong_instant_panic = "惊恐附近可惊恐的敌人 %s 秒."
 		},
-		cost = "Costs %s inspiration to use.",
+		cost = "Costs %s inspiration to use."
 	},
 
 	-- sinkholespawner.lua
 	antlion_rage = "%s",
 
 	-- skinner_beefalo.lua
-	skinner_beefalo = "Fearsome: %s, Festive: %s, Formal: %s",
+	skinner_beefalo = "凶猛: %s, 喜庆: %s, 正式: %s",
 
 	-- soul.lua
-	wortox_soul_heal = "<color=HEALTH>治疗</color> <color=HEALTH>%s</color> - <color=HEALTH>%s</color>.",
-	wortox_soul_heal_range = "<color=HEALTH>治疗</color> <color=#DED15E>%s 个格子</color> 内的玩家.",
+	wortox_soul_heal = "<color=HEALTH>治疗</color> <color=HEALTH>%s</color> - <color=HEALTH>%s</color>。",
+	wortox_soul_heal_range = "<color=HEALTH>治疗</color> <color=#DED15E>%s 个格子</color> 内的玩家。",
 
 	-- spawner.lua
 	spawner = {
-		next = "将生成 <color=MOB_SPAWN>%s</color> 于 %s",
-		child = "生成一个 <color=#ff9999>%s</color>",
+		next = "$2后生成 <color=MOB_SPAWN>$1</color>",
+		child = "生成一个 <color=#ff9999>%s</color>"
 	},
 
 	-- stagehand.lua [Prefab]
 	stagehand = {
 		hits_remaining = "剩余<color=#aaaaee>敲击</color>: <color=#aaaaee>%s</color>",
-		time_to_reset = "将重置于 %s."  
+		time_to_reset = "%s后重置"
 	},
 
 	-- stewer.lua
 	stewer = {
 		product = "<color=HUNGER><prefab=%s></color>(<color=HUNGER>%s</color>)",
-		cooktime_remaining ="<color=HUNGER><prefab=%s></color>(<color=HUNGER>%s</color>) 将在 %s 秒后完成",
+		cooktime_remaining = "<color=HUNGER><prefab=%s></color>(<color=HUNGER>%s</color>) 将在 %s 秒后完成。",
 		cooker = "由 <color=%s>%s</color> 烹饪",
-		cooktime_modifier_slower = "烹调食物 <color=#DED15E>%s%%</color> 减慢.",
-		cooktime_modifier_faster = "烹调食物 <color=NATURE>%s%%</color> 加快.",
+		cooktime_modifier_slower = "烹调食物 <color=#DED15E>%s%%</color> 减慢。",
+		cooktime_modifier_faster = "烹调食物 <color=NATURE>%s%%</color> 加快."
 	},
 
 	-- stickable.lua
@@ -650,25 +681,23 @@ return {
 	temperature = "温度: %s",
 
 	-- tigersharker.lua
-	tigershark_spawnin = "重生于: %s后",
+	tigershark_spawnin = "%s后重生",
 	tigershark_waiting = "重生准备就绪",
 	tigershark_exists = "当前虎鲨出没",
 
 	-- timer.lua
 	timer = {
 		label = "计时 '%s': %s",
-		paused = "暂停",
+		paused = "暂停"
 	},
 
 	-- tool.lua
 	action_efficiency = "<color=#DED15E>%s</color>: %s%%",
 	tool_efficiency = "<color=NATURE>效率</color> < %s >", -- #A5CEAD
-
 	-- tradable.lua
 	tradable_gold = "价值 %s 个金块",
 	tradable_gold_dubloons = "价值 %s 个金块和 %s 个金币",
-	tradable_rocktribute = "延迟<color=LIGHT>蚁狮</color>愤怒 %s天", -- needs to get updated to english equivelant
-
+	tradable_rocktribute = "延迟<color=LIGHT>蚁狮</color>愤怒 %s 天", -- needs to get updated to english equivelant
 	-- unwrappable.lua
 	-- handled by klei?
 
@@ -678,23 +707,23 @@ return {
 	upgradeable_incomplete = "不可升级",
 
 	-- walrus_camp.lua [Prefab]
-	walrus_camp_respawn = "<color=MOB_SPAWN><prefab=%s></color> 重生于: <color=FROZEN>%s后</color>",
+	walrus_camp_respawn = "<color=MOB_SPAWN><prefab=%s></color>重生于<color=FROZEN>%s后</color>",
 
 	-- waterproofer.lua
 	waterproofness = "<color=WET>防水</color>: <color=WET>%s%%</color>",
 
 	-- watersource.lua
-	watersource = "这是一个水源.",
+	watersource = "这是一个水源。",
 
 	-- wateryprotection.lua
 	wateryprotection = {
-		wetness = "Increases soil moisture by <color=WET>%s</color>."
+		wetness = "增加 <color=WET>%s</color> 土壤湿度"
 	},
 
 	-- weapon.lua
 	weapon_damage_type = {
 		normal = "<color=HEALTH>伤害</color>",
-		electric = "<color=WET>电系</color> <color=HEALTH>伤害</color>",
+		electric = "<color=WET>(电击)</color> <color=HEALTH>伤害</color>",
 		poisonous = "<color=NATURE>(毒性)</color> <color=HEALTH>伤害</color>",
 		thorns = "<color=HEALTH>(反弹)</color> <color=HEALTH>伤害</color>"
 	},
@@ -705,7 +734,7 @@ return {
 	weighable = {
 		weight = "重量: %s (%s%%)",
 		weight_bounded = "重量: %s <= %s (%s) <= %s",
-		owner_name = "主人: %s",
+		owner_name = "主人: %s"
 	},
 
 	-- werebeast.lua
@@ -716,8 +745,8 @@ return {
 
 	-- winch.lua
 	winch = {
-		not_winch = "This has a winch component, but fails prefab check.",
-		sunken_item = "There is a <color=#66ee66>%s</color> underneath this winch.",
+		not_winch = "这是一个夹夹绞盘组件，但是预设检查失败",
+		sunken_item = "夹夹绞盘底下有一个<color=#66ee66>%s</color>"
 	},
 
 	-- winterometer.lua [Prefab]
@@ -727,15 +756,15 @@ return {
 
 	-- wintertreegiftable.lua
 	wintertreegiftable = {
-		ready = "你已可以打开 <color=#DED15E>稀有礼物</color>.",
-		not_ready = "你必须 <color=#ffbbbb>等待 %s 天</color> 才能再次获得一个 <color=#DED15E>稀有礼物</color>.",
+		ready = "你已可以打开<color=#DED15E>稀有礼物</color>。",
+		not_ready = "你必须<color=#ffbbbb>等待 %s 天</color>才能再次获得一个<color=#DED15E>稀有礼物</color>."
 	},
 
 	-- witherable.lua
 	witherable = {
-		delay = "状态变化延迟 %s",
-		wither = "将枯萎于 %s",
-		rejuvenate = "将复长于 %s"
+		delay = "状态变化延迟%s",
+		wither = "%s后枯萎",
+		rejuvenate = "%s后复长"
 	},
 
 	-- workable.lua
@@ -745,21 +774,21 @@ return {
 
 	-- worldmigrator.lua
 	worldmigrator = {
-		disabled = "切换世界已被禁用.",
+		disabled = "切换世界已被禁用。",
 		target_shard = "目标世界: %s",
 		received_portal = "传送门: %s",
-		id = "这是 #: %s",
+		id = "这是 #: %s"
 	},
 
 	-- worldsettingstimer.lua
 	worldsettingstimer = {
-		label = "WSTimer '%s': %s",
-		paused = "Paused",
+		label = "世界计时器 '%s': %s",
+		paused = "已暂停"
 	},
 
 	-- wx78.lua [Prefab]
 	wx78_charge = "剩余充能: %s",
 
 	-- yotb_sewer.lua
-	yotb_sewer = "缝制将完成于: %s",
+	yotb_sewer = "缝制将完成于 %s"
 }

--- a/scripts/language/english.lua
+++ b/scripts/language/english.lua
@@ -274,7 +274,7 @@ return {
 		soil_plant = "Nutrients: [<color=NATURE>%+d<sub>F</sub></color>, <color=CAMO>%+d<sub>C</sub></color>, <color=INEDIBLE>%+d<sub>M</sub></color>]<sub>tile</sub> ([<color=NATURE>%+d<sub>F</sub></color>, <color=CAMO>%+d<sub>C</sub></color>, <color=INEDIBLE>%+d<sub>M</sub></color>]<sub>Δplant</sub>)*",
 		--soil_plant_tile = "Nutrients: [%+d<color=NATURE><sub>F</sub></color>, %+d<color=CAMO><sub>C</sub></color>, %+d<color=INEDIBLE><sub>M</sub></color>]<sup>tile</sup> ([<color=#bee391>%+d<sub>F</sub></color>, <color=#7a9c6e>%+d<sub>C</sub></color>, <color=INEDIBLE>%+d<sub>M</sub></color>]<sup>plantΔ</sup>   [<color=NATURE>%+d<sub>F</sub></color>, <color=CAMO>%+d<sub>C</sub></color>, <color=INEDIBLE>%+d<sub>M</sub></color>]<sup>tileΔ</sup>)",
 		--soil_plant_tile = "Nutrients: [%+d<color=NATURE><sub>F</sub></color>, %+d<color=CAMO><sub>C</sub></color>, %+d<color=INEDIBLE><sub>M</sub></color>]<sup>tile</sup> ([<color=NATURE>%+d<sub>F</sub></color>, <color=CAMO>%+d<sub>C</sub></color>, <color=INEDIBLE>%+d<sub>M</sub></color>]<sup>plantΔ</sup>   [<color=NATURE>%+d<sub>F</sub></color>, <color=CAMO>%+d<sub>C</sub></color>, <color=INEDIBLE>%+d<sub>M</sub></color>]<sup>tileΔ</sup>)",
-		soil_plant_tile = "Nutrients: [<color=NATURE>%+d<sub>F</sub></color>, <color=CAMO>%+d<sub>C</sub></color>, <color=INEDIBLE>%+d<sub>M</sub></color>]<sub>tile</sub>   ([<color=NATURE>%+d<sub>F</sub></color>, <color=CAMO>%+d<sub>C</sub></color>, <color=INEDIBLE>%+d<sub>M</sub></color>]<sub>Δplant</sub> [<color=NATURE>%+d<sub>F</sub></color>, <color=CAMO>%+d<sub>C</sub></color>, <color=INEDIBLE>%+d<sub>M</sub></color>]<sub>Δtile</sub>)",
+		soil_plant_tile = "Nutrients: [<color=NATURE>%+d<sub>F</sub></color>, <color=CAMO>%+d<sub>C</sub></color>, <color=INEDIBLE>%+d<sub>M</sub></color>]<sub>tile</sub>   ([<color=NATURE>%+d<sub>F</sub></color>, <color=CAMO>%+d<sub>C</sub></color>, <color=INEDIBLE>%+d<sub>M</sub></color>]<sub>Δplant</sub> [<color=NATURE>%+d<sub>F</sub></color>, <color=CAMO>%+d<sub>C</sub></color>, <color=INEDIBLE>%+d<sub>M</sub></color>]<sub>tileΔ</sub>)",
 		--soil_plant_tile_net = "Nutrients: [<color=NATURE>%+d<sub>F</sub></color>, <color=CAMO>%+d<sub>C</sub></color>, <color=INEDIBLE>%+d<sub>M</sub></color>] ([<color=NATURE>%+d<sub>F</sub></color>, <color=CAMO>%+d<sub>C</sub></color>, <color=INEDIBLE>%+d<sub>M</sub></color>] + [<color=NATURE>%+d<sub>F</sub></color>, <color=CAMO>%+d<sub>C</sub></color>, <color=INEDIBLE>%+d<sub>M</sub></color>] = [<color=NATURE>%+d<sub>F</sub></color>, <color=CAMO>%+d<sub>C</sub></color>, <color=INEDIBLE>%+d<sub>M</sub></color>])"
 	},
 
@@ -694,7 +694,7 @@ return {
 	-- weapon.lua
 	weapon_damage_type = {
 		normal = "<color=HEALTH>Damage</color>",
-		electric = "<color=WET>Electric</color> <color=HEALTH>Damage</color>",
+		electric = "<color=WET>(Electric)</color> <color=HEALTH>Damage</color>",
 		poisonous = "<color=NATURE>(Poisonous)</color> <color=HEALTH>Damage</color>",
 		thorns = "<color=HEALTH>(Thorns)</color> <color=HEALTH>Damage</color>"
 	},

--- a/scripts/util.lua
+++ b/scripts/util.lua
@@ -636,11 +636,10 @@ end
 -- @str string to replace
 -- @param replacing fields
 -- @return replaced string
-local _StringFormat = string.format
-string.format = function(str, ...)
-	str2 = _StringFormat(str, ...)
+function GetDescription(str, ...)
+	str2 = string.format(str, ...)
 	if(str2 == str) then
-		for index, field in ipairs{...} do
+		for index, field in pairs{...} do
 			str2 = str2:gsub("$" .. index,  field)
 		end
 		return str2

--- a/scripts/util.lua
+++ b/scripts/util.lua
@@ -630,5 +630,24 @@ function module.replaceupvalue(func, name, replacement)
 	end
 end
 
+
+--- Format string
+--- With supports for "$" replace-able
+-- @str string to replace
+-- @param replacing fields
+-- @return replaced string
+local _StringFormat = string.format
+string.format = function(str, ...)
+	str2 = _StringFormat(str, ...)
+	if(str2 == str) then
+		for index, field in ipairs{...} do
+			str2 = str2:gsub("$" .. index,  field)
+		end
+		return str2
+	end
+	return str2
+end
+
+
 -- end
 return module


### PR DESCRIPTION
Up to 673145ae8d3dd99677b5a2d9c41b960f843612b3

There are some expressions in chinese having different order of describing things. For example `Regenrating (something) in (sometime)` in english is translated to `(Sometime) after (something) generates` in chinese for fluency. The order of "thing" and "time" is different between the two languages, so does `%s` in text strings.

Redefined `string.format` in `util.lua` for solving. From `chinese.lua` line 30:
> In strings, you can use $1 to represent the first %s in original string, $2 as second %s, and so on. 
	   Eg. "Regenerating %s in %s" -> "$2后$1重新生长", the first %s is an entity name and the second is the time, 
	   however in chinese expressions the time usually goes first, the order of %s are changed, 
	   so use $1 and $2 to have flexible places of %s