### PR TITLE
Show the bonded beefalo's name in beefalo bell's tooltip

### DIFF
--- a/scripts/language/chinese.lua
+++ b/scripts/language/chinese.lua
@@ -176,6 +176,11 @@ return {
 		bearger_attack = "<prefab=bearger>会在%s后攻击"
 	},
 
+	-- beef_bell.lua [Prefab]
+	beef_bell = {
+		beefalo_name = "名称: %s",
+	},
+
 	-- beequeenhive.lua [Prefab]
 	beequeenhive = {
 		time_to_respawn = "<prefab=beequeen>会重生于%s后",

--- a/scripts/language/english.lua
+++ b/scripts/language/english.lua
@@ -177,6 +177,11 @@ return {
 		bearger_attack = "<prefab=bearger> will attack in %s."
 	},
 
+	-- beef_bell.lua [Prefab]
+	beef_bell = {
+		beefalo_name = "Name: %s",
+	},
+
 	-- beequeenhive.lua [Prefab]
 	beequeenhive = {
 		time_to_respawn = "<prefab=beequeen> will respawn in %s.",

--- a/scripts/language/portuguese.lua
+++ b/scripts/language/portuguese.lua
@@ -182,6 +182,11 @@ return {
 		bearger_attack = "<prefab=bearger> irá atacar em %s."
 	},
 
+	-- beef_bell.lua [Prefab]
+	beef_bell = {
+		beefalo_name = "Nome: %s",
+	},
+
 	-- beequeenhive.lua [Prefab]
 	beequeenhive = {
 		time_to_respawn = "<prefab=beequeen> irá reiniciar em %s.",

--- a/scripts/language/spanish.lua
+++ b/scripts/language/spanish.lua
@@ -177,6 +177,11 @@ return {
 		bearger_attack = "<prefab=bearger> will attack in %s."
 	},
 
+	-- beef_bell.lua [Prefab]
+	beef_bell = {
+		beefalo_name = "Nombre: %s",
+	},
+
 	-- beequeenhive.lua [Prefab]
 	beequeenhive = {
 		time_to_respawn = "<prefab=beequeen> will respawn in %s.",

--- a/scripts/prefab_descriptors/beef_bell.lua
+++ b/scripts/prefab_descriptors/beef_bell.lua
@@ -1,0 +1,38 @@
+--[[
+Copyright (C) 2020, 2021 penguin0616
+
+This file is part of Insight.
+
+The source code of this program is shared under the RECEX
+SHARED SOURCE LICENSE (version 1.0).
+The source code is shared for referrence and academic purposes
+with the hope that people can read and learn from it. This is not
+Free and Open Source software, and code is not redistributable
+without permission of the author. Read the RECEX SHARED
+SOURCE LICENSE for details
+The source codes does not come with any warranty including
+the implied warranty of merchandise.
+You should have received a copy of the RECEX SHARED SOURCE
+LICENSE in the form of a LICENSE file in the root of the source
+directory. If not, please refer to
+<https://raw.githubusercontent.com/Recex/Licenses/master/SharedSourceLicense/LICENSE.txt>
+]]
+
+-- beef_bell.lua [Prefab]
+local function Describe(inst, context)
+	local description = nil
+
+	local beefalo = inst:GetBeefalo()
+	if beefalo then
+		description = string.format(context.lstr.beef_bell.beefalo_name, beefalo.components.writeable:GetText())
+	end
+
+	return {
+		priority = 1,
+		description = description,
+	}
+end
+
+return {
+	Describe = Describe
+}


### PR DESCRIPTION
Show the bonded beefalo's name in beefalo bell's tooltip. If the beefalo is named "foobar", then the tooltip would be "Name: foobar".

I've added spanish and portugese translations from google translate of the English word "name". I do not speak these two languages but for such a simple word that should be the correct translation?