### PR TITLE
Update Chinese translation and more

### DIFF
--- a/modinfo.lua
+++ b/modinfo.lua
@@ -487,7 +487,7 @@ STRINGS = {
 	},
 	update_info = {
 		"See Steam changelog for more info.",
-		["zh"] = nil,
+		["zh"] = "查看Steam创意工坊页面的更新日志以了解更多信息。",
 		["br"] = "Uma *tonelada* de coisas. Você deve **realmente** verificar as Notas de Alterações do Steam.",
 		["es"] = nil,
 		["ru"] = "Добавлена информация об обновлениях From Beyond и других вещах. Смотрите список изменений Steam для получения дополнительной информации.",
@@ -6486,7 +6486,7 @@ STRINGS = {
 		},
 		hover = {
 			"Enables automatic reporting of crashes to the mod author.", 
-			["zh"] = nil,
+			["zh"] = "启用自动将崩溃报告发送给模组作者。",
 			["br"] = nil,
 			["es"] = nil,
 			["ru"] = nil,

--- a/modinfo.lua
+++ b/modinfo.lua
@@ -141,7 +141,9 @@ local function tostring(arg)
 end
 
 local function T(tbl, key)
-	if locale and ChooseTranslationTable then
+	if locale == "zht" then
+		return tbl["zh"] or tbl[1]
+	elseif locale and ChooseTranslationTable then
 		return ChooseTranslationTable(tbl, key)
 	else
 		return tbl["en"] or tbl[1]

--- a/scripts/language/chinese.lua
+++ b/scripts/language/chinese.lua
@@ -25,14 +25,14 @@ directory. If not, please refer to
 return {
 	-- insightservercrash.lua
 	crash_reporter = {
-		title = "[Insight Crash Reporter]",
+		title = "[Insight 崩溃报告器]",
 		crashed = "服务器崩溃",
 		report_status = {
-			unknown = "Unknown",
-			disabled = "The crash reporter is <color=#666666>disabled</color>: <color=#666666>%s</color>",
-			sending = "Sending crash report",
-			success = "Crash reported to Insight. <u>This does NOT mean that Insight caused the issue!</u>",
-			failure = "Crash report failed to send (%s): %s",
+			unknown = "未知",
+			disabled = "崩溃报告器已<color=#666666>禁用</color>：<color=#666666>%s</color>",
+			sending = "正在发送崩溃报告",
+			success = "崩溃已报告给 Insight <u>这并不意味着 Insight 导致了问题！</u>",
+			failure = "崩溃报告发送失败（%s）：%s",
 		},
 	},
 

--- a/scripts/language/chinese.lua
+++ b/scripts/language/chinese.lua
@@ -459,8 +459,8 @@ return {
 			description = "{duration} 秒内回复 <color=SANITY>{amount} 理智</color>",
 		},
 		["nightvision_buff"] = {
-			name = "<color=#258cd3>Night vision</color>",
-			description = "Provides <color=#258cd3>night vision</color> for {duration}(s).",
+			name = "<color=#258cd3>夜视</color>",
+			description = "提供<color=#258cd3>夜视</color>, 持续 {duration} 秒",
 		},
 		["wormlight_light"] = {
 			name = "<color=#6AD1EF><prefab=wormlight> light</color>",

--- a/scripts/language/icons.lua
+++ b/scripts/language/icons.lua
@@ -34,7 +34,7 @@ return {
 			--sending = "Sending crash report",
 			--success = "Crash reported to Insight. <u>This does NOT mean that Insight caused the issue!</u>",
 			--failure = "Crash report failed to send (%s): %s",
-		},
+		-- },
 	},
 
 	-- modmain.lua

--- a/scripts/language/language.lua
+++ b/scripts/language/language.lua
@@ -25,6 +25,7 @@ local languages = {
 	icons = "icons",
 	en = "english",
 	zh = "chinese", --ch = "chinese",
+	zht = "chinese",
 	es = "spanish", --mex = "spanish",
 	br = "portuguese",
 	ru = "russian",
@@ -45,7 +46,7 @@ local function PostImportLanguage(tbl)
 			local ret = v(tbl)
 			if type(ret) ~= "string" and type(ret) ~= "table" then
 				local info = debug.getinfo(v)
-				local src = (info.source or "?") .. ":" .. (info.linedefined or "?") 
+				local src = (info.source or "?") .. ":" .. (info.linedefined or "?")
 				mprint(type(ret))
 				mprint(ret)
 				errorf("Invalid post load fn for [%s]", src)
@@ -68,7 +69,7 @@ local function LoadLanguage(lang)
 	-- make sure none of the function returns in the langs directly return a reference to another table.
 	-- It's deceiving in that the deepcopy makes it seem like this should be fine, but you're setting a meta
 	-- On the same table twice from a single loaded language instance.
-	
+
 	local ret = deepcopy(tbl) -- Don't want to taint the import.
 
 	return ret
@@ -80,8 +81,8 @@ local function LoadLanguage(lang)
 end
 --]]
 
-local function __newindex(self) 
-	error(tostring(self) .. " is readonly") 
+local function __newindex(self)
+	error(tostring(self) .. " is readonly")
 end
 
 local function LinkTables(tbl, fallback)
@@ -134,7 +135,7 @@ local function main(config, locale)
 		-- However, I'm keeping this still to maintain load consistency across languages for testing purposes.
 
 		primary = LoadLanguage(languages[selected])
-		
+
 		LinkTables(primary, fallback)
 		rawset(primary, "lang", primary)
 		rawset(fallback, "lang", fallback)


### PR DESCRIPTION
Additionally, I have created Chinese translations for the strings returned by the `CanWeSendReport` function in `crashreporter.lua`.  
However, since localization support for these strings has not yet been implemented, I’m including them here for reference.  
Once localization support is added, these translations can be integrated into the Chinese language pack.

| English String                               | Chinese Translation              |
|----------------------------------------------|----------------------------------|
| server is opted in                           | 服务器已启用崩溃报告               |
| server owner has opted in                    | 服务器所有者已启用崩溃报告         |
| client host has opted in                     | 客户端主机已启用崩溃报告           |
| server did not find an authoritative opt-in  | 服务器未启用崩溃报告               |
| client has opted in                          | 客户端已启用崩溃报告               |
| client has not opted in                      | 客户端未启用崩溃报告               |
| user has opted in                            | 用户已启用崩溃报告                 |
| unknown state?                               | 未知状态？                        |