### PR TITLE
Release 6.0.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,356 @@
+languagetest.lua
+images/misc/testing
+anim/*/
+.vscode
+scripts/misc/console*
+
+##################################################
+# Lua.gitignore #
+##################################################
+# Compiled Lua sources
+luac.out
+
+# luarocks build files
+*.src.rock
+*.zip
+*.tar.gz
+
+# Object files
+*.o
+*.os
+*.ko
+*.obj
+*.elf
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Libraries
+*.lib
+*.a
+*.la
+*.lo
+*.def
+*.exp
+
+# Shared objects (inc. Windows DLLs)
+*.dll
+*.so
+*.so.*
+*.dylib
+
+# Executables
+*.exe
+*.out
+*.app
+*.i*86
+*.x86_64
+*.hex
+
+##################################################
+# Python.gitignore #
+##################################################
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[codz]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#   Usually these files are written by a python script from a template
+#   before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py.cover
+*.lcov
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+# Pipfile.lock
+
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+# uv.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+# poetry.lock
+# poetry.toml
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#   pdm recommends including project-wide configuration in pdm.toml, but excluding .pdm-python.
+#   https://pdm-project.org/en/latest/usage/project/#working-with-version-control
+# pdm.lock
+# pdm.toml
+.pdm-python
+.pdm-build/
+
+# pixi
+#   Similar to Pipfile.lock, it is generally recommended to include pixi.lock in version control.
+# pixi.lock
+#   Pixi creates a virtual environment in the .pixi directory, just like venv module creates one
+#   in the .venv directory. It is recommended not to include this directory in version control.
+.pixi/*
+!.pixi/config.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule*
+celerybeat.pid
+
+# Redis
+*.rdb
+*.aof
+*.pid
+
+# RabbitMQ
+mnesia/
+rabbitmq/
+rabbitmq-data/
+
+# ActiveMQ
+activemq-data/
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.envrc
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#   JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#   be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#   and can be added to the global gitignore or merged into this file.  For a more nuclear
+#   option (not recommended) you can uncomment the following to ignore the entire idea folder.
+# .idea/
+
+# Abstra
+#   Abstra is an AI-powered process automation framework.
+#   Ignore directories containing user credentials, local state, and settings.
+#   Learn more at https://abstra.io/docs
+.abstra/
+
+# Visual Studio Code
+#   Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
+#   that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
+#   and can be added to the global gitignore or merged into this file. However, if you prefer, 
+#   you could uncomment the following to ignore the entire vscode folder
+# .vscode/
+# Temporary file for partial code execution
+tempCodeRunnerFile.py
+
+# Ruff stuff:
+.ruff_cache/
+
+# PyPI configuration file
+.pypirc
+
+# Marimo
+marimo/_static/
+marimo/_lsp/
+__marimo__/
+
+# Streamlit
+.streamlit/secrets.toml
+
+##################################################
+# JetBrains.gitignore #
+##################################################
+
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# AWS User-specific
+.idea/**/aws.xml
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# SonarLint plugin
+.idea/sonarlint/
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser

--- a/doc/Adding Modded Information.md
+++ b/doc/Adding Modded Information.md
@@ -66,7 +66,6 @@ context = {
 	},
 	usingIcons = false, -- whether the user is using icon formatting
 	lstr = {...}, -- see scripts/language.lua
-	is_server_owner = true/false,
 	etc = {...}
 }
 ```

--- a/modinfo.lua
+++ b/modinfo.lua
@@ -7588,7 +7588,7 @@ configuration_options = {
 			{ data = true },
 		},
 		default = false,
-		tags = { "undefined" },
+		tags = {"undefined"},
 	},
 	{
 		name = "display_mob_attack_damage",
@@ -7616,7 +7616,7 @@ configuration_options = {
 			{data = true},
 		}, 
 		default = true,
-		tags = {},
+		tags = {"undefined"},
 	},
 	{
 		name = "display_harvestable",
@@ -7625,7 +7625,7 @@ configuration_options = {
 			{data = true},
 		}, 
 		default = true,
-		tags = {},
+		tags = {"undefined"},
 	},
 	{
 		name = "display_finiteuses",

--- a/modinfo.lua
+++ b/modinfo.lua
@@ -49,7 +49,7 @@ name = "Insight"
 -- MAJOR version when you make incompatible API changes
 -- MINOR version when you add functionality in a backward compatible manner
 -- PATCH version when you make backward compatible bug fixes
-version = "6.0.0"
+version = "6.0.1"
 --version_compatible = "0.0.0" -- Oldest version we are still compatible with
 author = "penguin0616"
 forumthread = ""

--- a/modmain.lua
+++ b/modmain.lua
@@ -265,7 +265,7 @@ local descriptors_ignore = {
 	"economy", "cityalarms", "banditmanager", "quaker_interior", "glowflyspawner", -- world (hamlet) (might be interesting)
 	"nightmareambientsoundmixer", --gamelogic
 	"colourcubemanager", "seasonmanager", "bigfooter", "flowerspawner", "doydoyspawner", "debugger", "rainbowjellymigration", "globalsettings", "flooding", "mosquitospawner", -- specific world types
-	"volcanoambience", "volcanowave", "whalehunter", -- specific world types
+	"volcanoambience", "volcanowave", -- specific world types
 	
 	
 	-- now for DST stuff
@@ -1070,13 +1070,13 @@ function AddComponentDescriptor(name, descriptor, metadata)
 		descriptor.metadata = metadata
 		if descriptor.OnServerLoad then
 			if IS_DS or TheNet:IsDedicated() or IsClientHost() then
-				descriptor.OnServerLoad()
+				descriptor:OnServerLoad()
 			end
 		end
 
 		if descriptor.OnClientLoad then
 			if IS_DS or IsClient() or IsClientHost() then
-				descriptor.OnClientLoad()
+				descriptor:OnClientLoad()
 			end
 		end
 	end
@@ -3158,6 +3158,7 @@ Insight.descriptors("clock")
 Insight.descriptors("oceanfishingrod")
 Insight.descriptors("container")
 Insight.descriptors("hunter")
+Insight.descriptors("whalehunter")
 Insight.descriptors("kramped")
 
 

--- a/modmain.lua
+++ b/modmain.lua
@@ -231,7 +231,7 @@ end
 --- @type PlayerContextManager
 local playerContextManager = import("services/playercontextmanager")
 Insight.API.V1.GetPlayerContext = function(...) return playerContextManager:GetContext(...) end
-local CrashReporter -- Initialized later, see comment below
+CrashReporter = nil -- Initialized later, see comment below
 local mod_component_cache = {}
 
 local log_buffer = ""

--- a/modmain.lua
+++ b/modmain.lua
@@ -1147,13 +1147,13 @@ function AddPrefabDescriptor(name, descriptor, metadata)
 		descriptor.metadata = metadata
 		if descriptor.OnServerLoad then
 			if IS_DS or TheNet:IsDedicated() or IsClientHost() then
-				descriptor.OnServerLoad()
+				descriptor:OnServerLoad()
 			end
 		end
 
 		if descriptor.OnClientLoad then
 			if IS_DS or IsClient() or IsClientHost() then
-				descriptor.OnClientLoad()
+				descriptor:OnClientLoad()
 			end
 		end
 	end

--- a/modmain.lua
+++ b/modmain.lua
@@ -228,8 +228,10 @@ if TheSim:GetGameID() == "DS" then
 	import("ds_patches/missing_globals")
 end
 
+--- @type PlayerContextManager
+local playerContextManager = import("services/playercontextmanager")
+Insight.API.V1.GetPlayerContext = function(...) return playerContextManager:GetContext(...) end
 local CrashReporter -- Initialized later, see comment below
-local player_contexts = {}
 local mod_component_cache = {}
 
 local log_buffer = ""
@@ -493,155 +495,6 @@ function GetLocalInsight(player)
 	end
 end
 
---- Returns player's insight context.
----@param player EntityScript
----@return table|nil @Wrapper of player's context
-function GetPlayerContext(player)
-	if not IsPrefab(player) then
-		error("[Insight]: GetPlayerContext called on non-player")
-	end
-
-	local context
-	if IS_DST and TheWorld.ismastersim then
-		-- i know we'll have it
-		context = player_contexts[player]
-	else
-		-- will be the only context
-		context = player_contexts[player]
-	end
-
-	if context then
-		return setmetatable({ FROM_INSPECTION=false }, { __index=context })
-	end
-
-	--return context
-end
-
-function ValidateComplexConfiguration(player, complex_config_table)
-	for name, config in pairs(modinfo.complex_configuration_options) do
-		local val = complex_config_table[name]
-		if config.type == "listbox" then
-			if type(val) ~= "table" then
-				complex_config_table[name] = {}
-				mprintf("!!!!!!!!!! %s had an invalid complex config for %s: %s (%s)", tostring(player), name, tostring(val), type(val))
-			end
-		end
-	end
-end
-
-local CONTEXT_META = {
-	__newindex = function()
-		error("context is readonly")
-	end;
-	--__tostring = function(self) return string.format("Player Context (%s): %s", tostring(self.player), self._name or "ADDR") end,
-	__metatable = "[Insight] The metatable is locked"
-}
-
---- Creates player's insight context.
----@param player EntityScript Player to create context for.
----@param configs table Holds the different config types: vanilla, external, complex.
----@param etc table
-function CreatePlayerContext(player, configs, etc)
-	if not player then
-		error("[Insight]: Player is missing!")
-	end
-
-	if type(configs.vanilla) ~= "table" then
-		if IS_DST then TheNet:Kick(player.userid) return end
-		error("[Insight]: Config is invalid!")
-	end
-
-	if type(configs.external) ~= "table" then
-		if IS_DST then TheNet:Kick(player.userid) return end
-		error("[Insight]: external config is invalid!")
-	end
-
-	if type(configs.complex) ~= "table" then
-		if IS_DST then TheNet:Kick(player.userid) return end
-		error("[Insight]: complex config is invalid!")
-	end
-
-	ValidateComplexConfiguration(player, configs.complex)
-	
-
-	local context = {
-		player = player,
-		config = configs.vanilla,
-		external_config = configs.external,
-		complex_config = configs.complex,
-		time = nil,
-		usingIcons = configs.vanilla["info_style"] == "icon",
-		lstr = language(configs.vanilla, etc.locale),
-		is_server_owner = etc.is_server_owner,
-		etc = etc
-	}
-
-	context.time = Time:new({ context=context })
-
-	if context.is_server_owner then
-		if context.config["crash_reporter"] then
-			CrashReporter.server_owner_optin = true
-			SyncSecondaryInsightData({ server_owner_optin=true })
-		end
-	end
-
-	setmetatable(context.config, CONTEXT_META)
-	setmetatable(context.external_config, CONTEXT_META)
-	setmetatable(context.complex_config, CONTEXT_META)
-	setmetatable(context, mt)
-
-
-	player_contexts[player] = context
-	mprint("Created player context for", player)
-end
-
---- Updates a player's context if they already have one.
----@param player EntityScript
----@param data table
-function UpdatePlayerContext(player, data)
-	local context = player_contexts[player]
-	if not context then
-		mprint("Can't update missing player context.")
-		return
-	end
-
-	local oldLang = context.config["language"]
-	if data.configs then
-		if type(data.configs.vanilla) ~= "table" then
-			if IS_DST then TheNet:Kick(player.userid) return end
-			error("[Insight]: UpdatePlayerContext Config is invalid!")
-		end
-
-		if type(data.configs.external) ~= "table" then
-			if IS_DST then TheNet:Kick(player.userid) return end
-			error("[Insight]: UpdatePlayerContext external config is invalid!")
-		end
-
-		if type(data.configs.complex) ~= "table" then
-			if IS_DST then TheNet:Kick(player.userid) return end
-			error("[Insight]: UpdatePlayerContext complex config is invalid!")
-		end
-
-		ValidateComplexConfiguration(player, data.configs.complex)
-
-		context.config = setmetatable(data.configs.vanilla, CONTEXT_META)
-		context.external_config = setmetatable(data.configs.external, CONTEXT_META)
-		context.complex_config = setmetatable(data.configs.complex, CONTEXT_META)
-	end
-	data.configs = nil
-
-	for i,v in pairs(data) do
-		context[i] = v
-	end
-
-	local oldUsingIcons = context.usingIcons
-	context.usingIcons = context.config["info_style"] == "icon"
-
-	if oldLang ~= context.config["language"] or oldUsingIcons ~= context.usingIcons then
-		context.lstr = language(context.config, context.etc.locale)
-		context.etc.locale = context.config["language"]
-	end
-end
 
 --- Returns the component's origin. 
 ---@param componentname string
@@ -842,6 +695,25 @@ function errorf(level, error_pattern, ...)
 	else
 		error("errorf bad args")
 	end
+end
+
+--- Does the bad argument error commonly seen thrown by misuse of native functions, but with more detail.
+--- @param pos number
+--- @param name The name of the function
+--- @param expected @What was expected
+--- @param actual @What was received
+function argerror(pos, name, expected, actual)
+	-- Resolve actual if it is an EntityScript
+	if type(actual) == "table" and type(actual.is_a) == "function" then
+		for name, val in pairs(getfenv(0)) do
+			if type(val) == "table" and type(rawget(val, "is_a")) == "function" and actual:is_a(val) then
+				actual = name .. " [" .. tostring(actual) .. "]"
+				break
+			end
+		end
+	end
+
+	return errorf("bad argument #%d to '%s' (%s expected, got %s)", pos, name, expected, actual)
 end
 
 --- Debug print that only shows if DEBUG_ENABLED is true.
@@ -1282,7 +1154,7 @@ local function GetEntityInformation(entity, player, params)
 	end
 	--]]
 
-	local player_context = GetPlayerContext(player)
+	local player_context = playerContextManager:GetContext(player)
 	if not player_context then
 		assembled.raw_information = nil
 		assembled.information = string.format("missing player context for %s (%s) | requested ent: %s", player.name, tostring(player), tostring(entity))
@@ -1538,7 +1410,7 @@ end
 function GetWorldInformation(player) -- refactor?
 	--if true then return {} end
 	local world = TheWorld or GetWorld() -- implict game check
-	local context = GetPlayerContext(player)
+	local context = playerContextManager:GetContext(player)
 	if not context then
 		return
 	end
@@ -2339,12 +2211,10 @@ if IS_DST then
 	rpcNetwork.AddModRPCHandler(modname, "ProcessConfiguration", function(player, data)
 		mprint("ProcessConfiguration", player)
 		data = json.decode(data)
-		if player_contexts[player] then
-			UpdatePlayerContext(player, {
-				configs = data.configs
-			})
+		if playerContextManager:HasContext(player) then
+			playerContextManager:UpdateContext(player, data.configs, data.etc)
 		else
-			CreatePlayerContext(player, data.configs, data.etc)
+			playerContextManager:CreateContext(player, data.configs, data.etc)
 		end
 	end)
 	
@@ -2436,7 +2306,7 @@ if IS_DST then
 			setfenv(fn, setmetatable({
 				tostr = tostr,
 				me = UserToPlayer(MyKleiID),
-				player_contexts = player_contexts,
+				player_contexts = playerContextManager:GetAllContexts(),
 			}, {
 				__index = Insight.env,
 				__newindex = Insight.env,
@@ -2940,7 +2810,7 @@ if IS_DST then
 
 		TheWorld:ListenForEvent("ms_playerleft", function(_, player)
 			mprintf("Player %s (userid: %s) left, removing context", player, player.userid)
-			player_contexts[player] = nil
+			playerContextManager:RemoveContext(player)
 		end)
 		
 		TheWorld:ListenForEvent("ms_cyclecomplete", function(inst)

--- a/scripts/clientmodmain.lua
+++ b/scripts/clientmodmain.lua
@@ -782,7 +782,7 @@ ClientCoreEventer:ListenForEvent("configuration_update", function()
 	DEBUG_ENABLED = config["DEBUG_ENABLED"]
 
 	if IS_DS or IsClient() then
-		playerContextManager:UpdatePlayerContext(localPlayer, {
+		playerContextManager:UpdateContext(localPlayer, {
 			{
 				vanilla = config,
 				external = GenerateExternalConfiguration(),

--- a/scripts/clientmodmain.lua
+++ b/scripts/clientmodmain.lua
@@ -31,6 +31,8 @@ local TheInput, TheInputProxy, TheGameService, TheShard, TheNet, FontManager, Po
 --======================================== Variables =======================================================================
 --==========================================================================================================================
 --==========================================================================================================================
+local playerContextManager = import("services/playercontextmanager")
+
 local attackRangeUtility = import("utility/attack_range")
 insightSaveData = import("utility/savedata")("mod_config_data/Insight_SaveData" .. (IS_DST and "_CLIENT" or ""));
 controlUtility = import("utility/control")
@@ -50,7 +52,7 @@ ClientCoreEventer = import("utility/eventer")()
 OnLocalPlayerPostInit = ClientCoreEventer:CreateEvent("OnLocalPlayerPostInit")
 OnLocalPlayerPostInit.onlisteneradded = function(listener)
 	if localPlayer then
-		listener:Run(GetLocalInsight(localPlayer), GetPlayerContext(localPlayer))
+		listener:Run(GetLocalInsight(localPlayer), playerContextManager:GetContext(localPlayer))
 	end
 end
 OnLocalPlayerRemove = ClientCoreEventer:CreateEvent("OnLocalPlayerRemove")
@@ -320,7 +322,7 @@ local function GenerateConfiguration()
 end
 
 local function IsPlayerClientLoaded(player)
-	return (player and player.HUD and GetLocalInsight(player) and GetPlayerContext(player) and true) or false
+	return (player and player.HUD and GetLocalInsight(player) and playerContextManager:GetContext(player) and true) or false
 end
 
 local function AddDeployHelper(inst)
@@ -368,7 +370,7 @@ function OnCurrentlySelectedItemChanged(old, new, itemInfo)
 		return
 	end
 
-	local context = GetPlayerContext(localPlayer)
+	local context = playerContextManager:GetContext(localPlayer)
 	if not context then
 		return
 	end
@@ -681,7 +683,7 @@ local function LoadLocalPlayer(player)
 	if IsPlayerClientLoaded(player) then
 		localPlayer = player
 		dprint("LOCALPLAYER ADDED", localPlayer)
-		local context = GetPlayerContext(player)
+		local context = playerContextManager:GetContext(player)
 		local insight = GetLocalInsight(localPlayer)
 		insight.context = context
 
@@ -722,7 +724,6 @@ function SendConfigurationToServer()
 			complex = GenerateComplexConfiguration(),
 		},
 		etc = {
-			is_server_owner = TheNet:GetIsServerOwner(),
 			locale = LOC.GetLocaleCode(),
 			DEBUG_ENABLED = DEBUG_ENABLED,
 			server_deaths = GetMorgueDeathsForWorld(TheNet:GetServerName()),
@@ -757,7 +758,7 @@ function NEW_VERSION_INFO_FN(button)
 				end },
 				{ text=presets, cb=function() 
 					popup:Close()
-					local scr = InsightPresetScreen(GetPlayerContext(localPlayer), modname)
+					local scr = InsightPresetScreen(playerContextManager:GetContext(localPlayer), modname)
 					TheFrontEnd:PushScreen(scr)
 				end },
 			}
@@ -781,11 +782,14 @@ ClientCoreEventer:ListenForEvent("configuration_update", function()
 	DEBUG_ENABLED = config["DEBUG_ENABLED"]
 
 	if IS_DS or IsClient() then
-		UpdatePlayerContext(localPlayer, {
-			configs = {
+		playerContextManager:UpdatePlayerContext(localPlayer, {
+			{
 				vanilla = config,
 				external = GenerateExternalConfiguration(),
 				complex = GenerateComplexConfiguration(),
+			},
+			{
+				locale = LOC.GetLocaleCode(),
 			}
 		})
 	end
@@ -794,7 +798,7 @@ ClientCoreEventer:ListenForEvent("configuration_update", function()
 		SendConfigurationToServer()
 	end
 
-	OnContextUpdate:Push(GetPlayerContext(localPlayer))
+	OnContextUpdate:Push(playerContextManager:GetContext(localPlayer))
 end)
 
 OnLocalPlayerPostInit:AddListener("highlighting_activate", highlighting.Activate)
@@ -1262,7 +1266,7 @@ AddPlayerPostInit(function(player)
 		end
 		delayed_actives = {}
 
-		CreatePlayerContext(
+		playerContextManager:CreateContext(
 			player, 
 			{
 				vanilla = GenerateConfiguration(),
@@ -1270,7 +1274,6 @@ AddPlayerPostInit(function(player)
 				complex = GenerateComplexConfiguration(),
 			},
 			{
-				is_server_owner = true,
 				locale = LOC.GetLocaleCode(),
 			}
 		)
@@ -1326,7 +1329,7 @@ AddPlayerPostInit(function(player)
 		end)
 
 		if IsClient() then -- create local copy for clients
-			CreatePlayerContext(
+			playerContextManager:CreateContext(
 				player, 
 				{
 					vanilla = GenerateConfiguration(),
@@ -1334,7 +1337,6 @@ AddPlayerPostInit(function(player)
 					complex = GenerateComplexConfiguration(),
 				},
 				{
-					is_server_owner = TheNet:GetIsServerOwner(),
 					locale = LOC.GetLocaleCode(),
 				}
 			)

--- a/scripts/components/insight.lua
+++ b/scripts/components/insight.lua
@@ -156,7 +156,7 @@ local Insight = Class(function(self, inst)
 
 
 	self.inst:ListenForEvent("newfishingtarget", function(player, data)
-		local context = GetPlayerContext(player)
+		local context = Insight.API.GetPlayerContext(player)
 		
 		if not context.config["display_oceanfishing"] then
 			return
@@ -226,7 +226,7 @@ function Insight:SendNaughtiness()
 		return
 	end
 
-	local data = naughtyFn(self.inst, GetPlayerContext(self.inst))
+	local data = naughtyFn(self.inst, Insight.API.GetPlayerContext(self.inst))
 	-- This will fail intially in client hosted since it'll get called before the player shows up in kramped data.
 	if type(data) ~= "table" or type(data.actions) ~= "number" or type(data.threshold) ~= "number" then
 		mprint("Insight:SendNaughtiness() -> GetPlayerNaughtinessData failed:", tbl)

--- a/scripts/components/insight.lua
+++ b/scripts/components/insight.lua
@@ -156,7 +156,7 @@ local Insight = Class(function(self, inst)
 
 
 	self.inst:ListenForEvent("newfishingtarget", function(player, data)
-		local context = Insight.API.GetPlayerContext(player)
+		local context = _G.Insight.API.GetPlayerContext(player)
 		
 		if not context.config["display_oceanfishing"] then
 			return
@@ -226,7 +226,7 @@ function Insight:SendNaughtiness()
 		return
 	end
 
-	local data = naughtyFn(self.inst, Insight.API.GetPlayerContext(self.inst))
+	local data = naughtyFn(self.inst, _G.Insight.API.GetPlayerContext(self.inst))
 	-- This will fail intially in client hosted since it'll get called before the player shows up in kramped data.
 	if type(data) ~= "table" or type(data.actions) ~= "number" or type(data.threshold) ~= "number" then
 		mprint("Insight:SendNaughtiness() -> GetPlayerNaughtinessData failed:", tbl)

--- a/scripts/components/shard_insight.lua
+++ b/scripts/components/shard_insight.lua
@@ -94,7 +94,7 @@ local Shard_Insight = Class(function(self, inst)
 		"toadstoolspawner",
 		"daywalkerspawner"
 	}) do
-		self.shard_descriptors[value] = Insight.descriptors[value] and Insight.descriptors[value].RemoteDescribe or nil
+		self:RegisterDescriptor(value, Insight.descriptors[value] and Insight.descriptors[value].RemoteDescribe or nil)
 	end
 
 	self.local_data = nil

--- a/scripts/descriptors/health.lua
+++ b/scripts/descriptors/health.lua
@@ -59,7 +59,8 @@ local function Describe(self, context)
 		local percent = self.currenthealth / max_health
 		alt_description = description .. string.format(" (<color=HEALTH>%s%%</color>)", Round(percent * 100, 0))
 
-		if self.regen then -- regeneration
+		-- People are screwing with things again, so we have to verify amount and period are actual numbers. Ugh.
+		if type(self.regen) == "table" and type(self.regen.amount) == "number" and type(self.regen.period) == "number" then -- regeneration
 			local regen = string.format(context.lstr.health_regeneration, Round(self.regen.amount, 1), Round(self.regen.period, 1))
 			description = description .. regen
 			alt_description = alt_description .. regen

--- a/scripts/descriptors/hunter.lua
+++ b/scripts/descriptors/hunter.lua
@@ -125,7 +125,7 @@ local function Hunter_OnDirtInvestigated(self, pt, doer, ...)
 		return
 	end
 
-	local context = active_player and GetPlayerContext(active_player)
+	local context = active_player and Insight.API.GetPlayerContext(active_player)
 	if not context or not context.config then
 		mprint("player context is invalid. player:", active_player)
 		if context then

--- a/scripts/descriptors/inspectable.lua
+++ b/scripts/descriptors/inspectable.lua
@@ -89,7 +89,7 @@ local function PlayerDescribe(self, context)
 	local inst = self.inst
 
 	if false and (DEBUG_ENABLED or inst ~= context.player) and inst.userid ~= "" then
-		local their_context = GetPlayerContext(inst)
+		local their_context = Insight.API.GetPlayerContext(inst)
 		if their_context and their_context.etc.server_deaths then
 			table.insert(stuff, GetPlayerServerDeaths(context, #their_context.etc.server_deaths))
 		end

--- a/scripts/descriptors/oceanfishingrod.lua
+++ b/scripts/descriptors/oceanfishingrod.lua
@@ -37,7 +37,6 @@ directory. If not, please refer to
 local RichFollowText = import("widgets/richfollowtext")
 local followtext = nil
 
-
 --~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 --~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Server Logic ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 --~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -191,7 +190,7 @@ local function SERVER_UpdateFishingBattleState(player)
 end
 
 local function SERVER_OnFishHooked(player, fish)
-	local context = GetPlayerContext(player)
+	local context = Insight.API.GetPlayerContext(player)
 	--[[
 	if not context.config["display_oceanfishing"] then
 		return
@@ -288,7 +287,7 @@ local function CLIENT_UpdateInterestedFish(player, data)
 		return
 	end
 
-	local context = GetPlayerContext(player)
+	local context = Insight.API.GetPlayerContext(player)
 
 	local interested = data.interested
 
@@ -339,7 +338,7 @@ local function CLIENT_UpdateFishingBattleState(player, data)
 		return
 	end
 
-	local context = GetPlayerContext(player)
+	local context = Insight.API.GetPlayerContext(player)
 
 	-- Tension
 	local tension_color = GREEN:Lerp(RED, math.min(data.tension.current / data.tension.max, 1)):ToHex()

--- a/scripts/descriptors/questowner.lua
+++ b/scripts/descriptors/questowner.lua
@@ -50,7 +50,7 @@ local function OnPipspookQuestBegin(inst, doer)
 		return
 	end
 
-	local context = GetPlayerContext(doer)
+	local context = Insight.API.GetPlayerContext(doer)
 	if not context then
 		dprint("pipspook quest missing player context, trying again in 1 second.") -- could i just pass contexts between shards?
 		return inst:DoTaskInTime(1, function() OnPipspookQuestBegin(inst, doer) end)

--- a/scripts/descriptors/tigersharker.lua
+++ b/scripts/descriptors/tigersharker.lua
@@ -19,6 +19,13 @@ directory. If not, please refer to
 ]]
 
 -- tigershark.lua [Worldly]
+local world_type = GetWorldType()
+
+-- I guess people are creating custom components of this but are removing functions like TimeUntilCanAppear.
+if world_type ~= 2 then
+	return {}
+end
+
 local function Describe(self, context)
 	-- SW only
 	local description = nil

--- a/scripts/descriptors/weapon.lua
+++ b/scripts/descriptors/weapon.lua
@@ -138,6 +138,10 @@ local function Describe(self, context)
 	-- Get Damage
 	local damage = GetDamage(self, owner, nil) or owner.components.combat.defaultdamage
 
+	if type(damage) ~= "number" then
+		return
+	end
+
 	-- i think this goes here?
 	if context.player.prefab == "wanda" then
 		damage = damage * WandaCustomCombatDamage(context.player, nil, self.inst, nil, context.player.components.rider and context.player.components.rider.mount or nil)
@@ -176,9 +180,10 @@ local function Describe(self, context)
 		attack_range = string.format(context.lstr.attack_range, attack_range)
 	end
 
-	local damage_string = string.format(context.lstr.weapon_damage, context.lstr.weapon_damage_type[stimuli_data.name] or context.lstr.weapon_damage_type.normal, Round(damage * multiplier, 1) or "?")
-
-	
+	local damage_string = string.format(context.lstr.weapon_damage, 
+		context.lstr.weapon_damage_type[stimuli_data.name] or context.lstr.weapon_damage_type.normal, 
+		Round(damage * multiplier, 1) or "?"
+	)
 
 	-- Other stuff
 	local pillow_info = self.inst:HasTag("pillow") and DescribeYOTRPillowWeapon(self, context) or nil

--- a/scripts/descriptors/whalehunter.lua
+++ b/scripts/descriptors/whalehunter.lua
@@ -90,7 +90,7 @@ local function Hunter_OnDirtInvestigated(self, pt, doer, ...)
 		return
 	end
 
-	local context = active_player and GetPlayerContext(active_player)
+	local context = active_player and Insight.API.GetPlayerContext(active_player)
 	if not context or not context.config then
 		mprint("player context is invalid. player:", active_player)
 		if context then

--- a/scripts/descriptors/whalehunter.lua
+++ b/scripts/descriptors/whalehunter.lua
@@ -18,56 +18,12 @@ directory. If not, please refer to
 <https://raw.githubusercontent.com/Recex/Licenses/master/SharedSourceLicense/LICENSE.txt>
 ]]
 
--- hunter.lua
-local module = {
-	initialized = false,
-	active_hunts = {},
-}
-local world_type = GetWorldType()
-
---- Calculates the chance of getting one of the alternate beasts, i.e. not a Koalefant.
---- @param self table
---- @return number
-function module.GetAlternateBeastChance(self)
-	if world_type == 0 then
-		return nil
-	end
-
-    local day = world_type == -1 and TheWorld.state.cycles or GetClock():GetNumCycles()
-    local chance = Lerp(TUNING.HUNT_ALTERNATE_BEAST_CHANCE_MIN, TUNING.HUNT_ALTERNATE_BEAST_CHANCE_MAX, day/100)
-    return math.clamp(chance, TUNING.HUNT_ALTERNATE_BEAST_CHANCE_MIN, TUNING.HUNT_ALTERNATE_BEAST_CHANCE_MAX)
+-- whalehunter.lua
+if not Insight.descriptors.hunter then
+	return {}
 end
 
---- Fetches the active hunt data from the dirt track.
---- @param self table
---- @param inst EntityScript The dirt track.
---- @return table @The hunt data.
-function module.GetHuntFromTrack(self, inst)
-	for i = 1, #self.active_hunts do
-		local hunt = self.active_hunts[i]
-		if hunt.lastdirt == inst then
-			return hunt
-		end
-	end
-end
-
---- Fetches the hunt data for the specific track.
---- @param self table
---- @param inst The dirt track.
-function module.GetHuntDataFromTrack(self, inst)
-	local hunt = self:GetHuntFromTrack(inst)
-
-	if not hunt then
-		return
-	end
-
-	return {
-		trackspawned = hunt.trackspawned,
-		numtrackstospawn = hunt.numtrackstospawn,
-		ambush_track_num = hunt.ambush_track_num,
-		chance_of_alternate_beast = self:GetAlternateBeastChance() -- consider caching?
-	}
-end
+local module = deepcopy(Insight.descriptors.hunter)
 
 --- Replacement for the OnDirtInvestigated function.
 --- @param self hunter
@@ -200,7 +156,7 @@ function module.OnServerLoad(self)
 
 	self.initialized = true
 
-	AddComponentPostInit("hunter", OnHunterPostInit)
+	AddComponentPostInit("whalehunter", OnHunterPostInit)
 end
 
 return module

--- a/scripts/descriptors/whalehunter.lua
+++ b/scripts/descriptors/whalehunter.lua
@@ -23,7 +23,16 @@ if not Insight.descriptors.hunter then
 	return {}
 end
 
-local module = deepcopy(Insight.descriptors.hunter)
+local module = {
+	initialized = false,
+	active_hunts = {},
+}
+
+for i,v in pairs(Insight.descriptors.hunter) do
+	if type(v) == "function" then
+		module[i] = v
+	end
+end
 
 --- Replacement for the OnDirtInvestigated function.
 --- @param self hunter

--- a/scripts/descriptors/whalehunter.lua
+++ b/scripts/descriptors/whalehunter.lua
@@ -108,11 +108,11 @@ local function Hunter_OnDirtInvestigated(self, pt, doer, ...)
 	local target = hunt.lastdirt or hunt.huntedbeast
 
 	if not target then
-		mprint(string.format("Hunter '%s' missing target, aborting.", activeplayer.name))
+		mprint(string.format("Hunter '%s' missing target, aborting.", active_player.name))
 		table.foreach(hunt, mprint)
 		return
 	else
-		--dprint("Sending", activeplayer, "on a hunt for:", target, "|", hunt.trackspawned, hunt.numtrackstospawn)
+		--dprint("Sending", active_player, "on a hunt for:", target, "|", hunt.trackspawned, hunt.numtrackstospawn)
 	end
 
 	if target.prefab == "claywarg" or target.prefab == "warg" or target.prefab == "spat" then

--- a/scripts/language/chinese.lua
+++ b/scripts/language/chinese.lua
@@ -377,6 +377,21 @@ return {
 
 	},
 
+	-- containerinstallableitem.lua
+	containerinstallableitem = {
+		slingshot_band = {
+			range = "Increases range by <color=FRUIT>%s</color>",
+			speed = "Increases projectile speed by <color=FRUIT>%.0f%%</color>",
+			slingshot_band_mimic = "%d%% chance not to consume ammo.",
+		},
+		slingshot_handle = {
+			fire_rate = "%.1f/s",
+			fire_rate_ramping = "%.1f/s → %.1f/s",
+			primary_fire_rate = "Primary fire rate: %s",
+			secondary_fire_rate = "Secondary fire rate: %s",
+		},
+	},
+
 	-- cooldown.lua
 	cooldown = "冷却: %s",
 

--- a/scripts/language/icons.lua
+++ b/scripts/language/icons.lua
@@ -373,6 +373,21 @@ return {
 		
 	},
 
+	-- containerinstallableitem.lua
+	containerinstallableitem = {
+		slingshot_band = {
+			--range = "Increases range by <color=FRUIT>%s</color>",
+			--speed = "Increases projectile speed by <color=FRUIT>%.0f%%</color>",
+			--slingshot_band_mimic = "%d%% chance not to consume ammo.",
+		},
+		slingshot_handle = {
+			--fire_rate = "%.1f/s",
+			--fire_rate_ramping = "%.1f/s → %.1f/s",
+			--primary_fire_rate = "Primary fire rate: %s",
+			--secondary_fire_rate = "Secondary fire rate: %s",
+		},
+	},
+
 	-- cooldown.lua
 	--cooldown = "Cooldown: %s",
 

--- a/scripts/language/korean.lua
+++ b/scripts/language/korean.lua
@@ -381,6 +381,21 @@ return {
 		
 	},
 
+	-- containerinstallableitem.lua
+	containerinstallableitem = {
+		slingshot_band = {
+			range = "Increases range by <color=FRUIT>%s</color>",
+			speed = "Increases projectile speed by <color=FRUIT>%.0f%%</color>",
+			slingshot_band_mimic = "%d%% chance not to consume ammo.",
+		},
+		slingshot_handle = {
+			fire_rate = "%.1f/s",
+			fire_rate_ramping = "%.1f/s → %.1f/s",
+			primary_fire_rate = "Primary fire rate: %s",
+			secondary_fire_rate = "Secondary fire rate: %s",
+		},
+	},
+
 	-- cooldown.lua
 	cooldown = "쿨타임: %s",
 

--- a/scripts/language/portuguese.lua
+++ b/scripts/language/portuguese.lua
@@ -382,6 +382,21 @@ return {
 		
 	},
 
+	-- containerinstallableitem.lua
+	containerinstallableitem = {
+		slingshot_band = {
+			range = "Increases range by <color=FRUIT>%s</color>",
+			speed = "Increases projectile speed by <color=FRUIT>%.0f%%</color>",
+			slingshot_band_mimic = "%d%% chance not to consume ammo.",
+		},
+		slingshot_handle = {
+			fire_rate = "%.1f/s",
+			fire_rate_ramping = "%.1f/s → %.1f/s",
+			primary_fire_rate = "Primary fire rate: %s",
+			secondary_fire_rate = "Secondary fire rate: %s",
+		},
+	},
+
 	-- cooldown.lua
 	cooldown = "Tempo restante: %s",
 

--- a/scripts/language/russian.lua
+++ b/scripts/language/russian.lua
@@ -378,6 +378,21 @@ return {
 		
 	},
 
+	-- containerinstallableitem.lua
+	containerinstallableitem = {
+		slingshot_band = {
+			range = "Increases range by <color=FRUIT>%s</color>",
+			speed = "Increases projectile speed by <color=FRUIT>%.0f%%</color>",
+			slingshot_band_mimic = "%d%% chance not to consume ammo.",
+		},
+		slingshot_handle = {
+			fire_rate = "%.1f/s",
+			fire_rate_ramping = "%.1f/s → %.1f/s",
+			primary_fire_rate = "Primary fire rate: %s",
+			secondary_fire_rate = "Secondary fire rate: %s",
+		},
+	},
+
 	-- cooldown.lua
 	cooldown = "Перезарядка: %s",
 

--- a/scripts/language/thai.lua
+++ b/scripts/language/thai.lua
@@ -360,6 +360,21 @@ return {
 		
 	},
 
+	-- containerinstallableitem.lua
+	containerinstallableitem = {
+		slingshot_band = {
+			range = "Increases range by <color=FRUIT>%s</color>",
+			speed = "Increases projectile speed by <color=FRUIT>%.0f%%</color>",
+			slingshot_band_mimic = "%d%% chance not to consume ammo.",
+		},
+		slingshot_handle = {
+			fire_rate = "%.1f/s",
+			fire_rate_ramping = "%.1f/s → %.1f/s",
+			primary_fire_rate = "Primary fire rate: %s",
+			secondary_fire_rate = "Secondary fire rate: %s",
+		},
+	},
+
 	-- cooldown.lua
 	cooldown = "คูลดาวน์: %s",
 

--- a/scripts/objects/playercontext.lua
+++ b/scripts/objects/playercontext.lua
@@ -1,0 +1,101 @@
+--[[
+Copyright (C) 2020, 2021 penguin0616
+
+This file is part of Insight.
+
+The source code of this program is shared under the RECEX
+SHARED SOURCE LICENSE (version 1.0).
+The source code is shared for referrence and academic purposes
+with the hope that people can read and learn from it. This is not
+Free and Open Source software, and code is not redistributable
+without permission of the author. Read the RECEX SHARED
+SOURCE LICENSE for details
+The source codes does not come with any warranty including
+the implied warranty of merchandise.
+You should have received a copy of the RECEX SHARED SOURCE
+LICENSE in the form of a LICENSE file in the root of the source
+directory. If not, please refer to
+<https://raw.githubusercontent.com/Recex/Licenses/master/SharedSourceLicense/LICENSE.txt>
+]]
+
+local language = import("language/language")
+
+local PlayerContext = {}
+
+PlayerContext.__index = PlayerContext
+PlayerContext._newindex = function() error("context is readonly") end -- I shouldn't be using context to exchange descriptor information anymore.
+--PlayerContext.__tostring = function(self) return string.format("Player Context (%s): %s", tostring(self.player), self._name or "ADDR") end,
+PlayerContext.__metatable = "[Insight] The metatable is locked" -- No touchy!
+
+--- Validation/fixup for complex configuration.
+--- @param player EntityScript
+--- @param complex_config_table table
+local function ValidateComplexConfiguration(player, complex_config_table)
+	for name, config in pairs(modinfo.complex_configuration_options) do
+		local val = complex_config_table[name]
+		if config.type == "listbox" then
+			if type(val) ~= "table" then
+				complex_config_table[name] = {}
+				mprintf("!!!!!!!!!! %s had an invalid complex config for %s: %s (%s)", tostring(player), name, tostring(val), type(val))
+			end
+		end
+	end
+end
+
+--- Creates a new instance of a player context.
+--- @param player EntityScript Player entity.
+--- @param configs table The sets of configuration options that the player currently has -- vanilla, external, and complex.
+--- @param etc table etc. I should have named this better :(
+--- @return PlayerContext @The created player context
+function PlayerContext.new(player, configs, etc)
+	if not (type(player) == "table" and type(player.is_a) == "function" and player:is_a(EntityScript)) then
+		argerror(1, "new", "EntityScript", player)
+	end
+
+	if type(configs.vanilla) ~= "table" then
+		if IS_DST then TheNet:Kick(player.userid) return end -- Only reason this is going to happen in DST is due to someone being naughty.
+		error("[Insight]: Config is invalid!")
+	end
+
+	if type(configs.external) ~= "table" then
+		if IS_DST then TheNet:Kick(player.userid) return end -- Only reason this is going to happen in DST is due to someone being naughty.
+		error("[Insight]: external config is invalid!")
+	end
+
+	if type(configs.complex) ~= "table" then
+		if IS_DST then TheNet:Kick(player.userid) return end -- Only reason this is going to happen in DST is due to someone being naughty.
+		error("[Insight]: complex config is invalid!")
+	end
+
+	ValidateComplexConfiguration(player, configs.complex)
+
+	local context = {
+		player = player,
+		config = configs.vanilla,
+		external_config = configs.external,
+		complex_config = configs.complex,
+		time = nil,
+		usingIcons = configs.vanilla["info_style"] == "icon",
+		lstr = language(configs.vanilla, etc.locale),
+		etc = etc
+	}
+
+	context.time = Time:new({ context=context })
+
+	-- Uses Klei ID.
+	if TheNet:GetIsServerOwner(player.Network:GetUserID()) then
+		if context.config["crash_reporter"] then
+			CrashReporter.server_owner_optin = true
+			SyncSecondaryInsightData({ server_owner_optin=true })
+		end
+	end
+
+	setmetatable(context.config, {__newindex = function() error("config is readonly") end, __metatable = "[Insight] The metatable is locked" })
+	setmetatable(context.external_config, {__newindex = function() error("external_config is readonly") end, __metatable = "[Insight] The metatable is locked" })
+	setmetatable(context.complex_config, {__newindex = function() error("complex_config is readonly") end, __metatable = "[Insight] The metatable is locked" })
+	setmetatable(context, PlayerContext)
+
+	return context
+end
+
+return PlayerContext

--- a/scripts/objects/playercontext.lua
+++ b/scripts/objects/playercontext.lua
@@ -52,9 +52,17 @@ function PlayerContext.new(player, configs, etc)
 		argerror(1, "new", "EntityScript", player)
 	end
 
+	if type(configs) ~= "table" then
+		argerror(2, "new", "table", type(configs))
+	end
+
+	if type(etc) ~= "table" then
+		argerror(3, "new", "table", type(etc))
+	end
+
 	if type(configs.vanilla) ~= "table" then
 		if IS_DST then TheNet:Kick(player.userid) return end -- Only reason this is going to happen in DST is due to someone being naughty.
-		error("[Insight]: Config is invalid!")
+		error("[Insight]: vanilla config is invalid!")
 	end
 
 	if type(configs.external) ~= "table" then

--- a/scripts/prefab_descriptors/archive_orchestrina_main.lua
+++ b/scripts/prefab_descriptors/archive_orchestrina_main.lua
@@ -69,7 +69,7 @@ local function OrchestrinaSmallPostInit(inst)
 	end
 
 	inst:ListenForEvent("insight_active_dirty", function(inst)
-		local context = localPlayer and GetPlayerContext(localPlayer)
+		local context = localPlayer and Insight.API.GetPlayerContext(localPlayer)
 
 		if not context or not context.config["orchestrina_indicator"] then
 			return

--- a/scripts/prefab_descriptors/atrium_gate.lua
+++ b/scripts/prefab_descriptors/atrium_gate.lua
@@ -27,7 +27,7 @@ local function GetCooldownData(inst)
 	-- cooldown = time before can resocket the key
 	-- destabilizedelay = time before can pulse on rejoin
 	if R15_QOL_WORLDSETTINGS then
-		atriumgate_timer = inst.components.worldsettingstimer and inst.components.worldsettingstimer:GetTimeLeft("cooldown") or 0
+		atriumgate_timer = inst.components.worldsettingstimer and inst.components.worldsettingstimer:GetTimeLeft("cooldown") or nil
 	else
 		atriumgate_timer = inst.components.timer:GetTimeLeft("cooldown")
 	end
@@ -79,7 +79,6 @@ end
 
 return {
 	GetCooldownData = GetCooldownData,
-
 	RemoteDescribe = RemoteDescribe,
 	StatusAnnouncementsDescribe = StatusAnnouncementsDescribe
 }

--- a/scripts/prefab_descriptors/dirtpile.lua
+++ b/scripts/prefab_descriptors/dirtpile.lua
@@ -19,15 +19,50 @@ directory. If not, please refer to
 ]]
 
 -- dirtpile.lua [Prefab]
-local function Describe(inst, context)
-	local description = "<color=#FF0000>Unable to load hunter descriptor.</color>"
+local function DescribeTrack(descriptor, inst, context)
+	--[[
+	for _, hunt in pairs(Insight.active_hunts) do
+			if hunt.lastdirt == inst then
+				local ambush_track_num = hunt.ambush_track_num
+				description = string.format(context.lstr.hunt_progress, hunt.trackspawned + 1, hunt.numtrackstospawn)
+
+				if ambush_track_num == hunt.trackspawned + 1 then
+					description = CombineLines(description, "There is an ambush waiting on the next track.")
+				end
+				break
+			end
+		end
+	--]]
+
+	local hunt_data = descriptor:GetHuntDataFromTrack(inst)
+
+	if not hunt_data then
+		--dprintf("no hunt data found for track %s", inst)
+		return
+	end
+
+	local progress = string.format(context.lstr.hunter.hunt_progress, hunt_data.trackspawned + 1, hunt_data.numtrackstospawn) -- +1 to make it look better
+	local ambush = nil
+	if hunt_data.ambush_track_num and hunt_data.ambush_track_num == hunt_data.trackspawned + 1 then -- will it spawn on the next track?
+		ambush = context.lstr.hunter.impending_ambush
+	end
+	local chance = hunt_data.chance_of_alternate_beast and (hunt_data.trackspawned+1 == hunt_data.numtrackstospawn) and string.format(context.lstr.hunter.alternate_beast_chance, Round(hunt_data.chance_of_alternate_beast * 100, 0)) or nil
+
+	local description = CombineLines(progress, ambush, chance)
 
 	return {
+		name = "hunter",
 		priority = 0,
 		description = description
 	}
 end
 
+
+local function Describe(inst, context)
+	return DescribeTrack(Insight.descriptors.hunter, inst, context)
+end
+
 return {
-	Describe = Insight.descriptors.hunter and Insight.descriptors.hunter.DescribeTrack or Describe
+	Describe = Describe,
+	DescribeTrack = DescribeTrack
 }

--- a/scripts/prefab_descriptors/tumbleweed.lua
+++ b/scripts/prefab_descriptors/tumbleweed.lua
@@ -139,7 +139,7 @@ local function OnLootDirty(inst)
 		return 
 	end
 
-	local context = GetPlayerContext(localPlayer)
+	local context = Insight.API.GetPlayerContext(localPlayer)
 	if not context.config["tumbleweed_info"] then
 		if inst.insight_loot then
 			inst.AnimState:SetAddColour(0, 0, 0, 0)

--- a/scripts/prefab_descriptors/whale_bubbles.lua
+++ b/scripts/prefab_descriptors/whale_bubbles.lua
@@ -20,14 +20,11 @@ directory. If not, please refer to
 
 -- whale_bubbles.lua [Prefab]
 local function Describe(inst, context)
-	local description = "<color=#FF0000>Unable to load hunter descriptor.</color>"
-
-	return {
-		priority = 0,
-		description = description
-	}
+	if Insight.prefab_descriptors.dirtpile then
+		return Insight.prefab_descriptors.dirtpile.DescribeTrack(Insight.descriptors.whalehunter, inst, context)
+	end
 end
 
 return {
-	Describe = Insight.descriptors.hunter and Insight.descriptors.hunter.DescribeTrack or Describe
+	Describe = Describe
 }

--- a/scripts/prefab_descriptors/wx78_scanner.lua
+++ b/scripts/prefab_descriptors/wx78_scanner.lua
@@ -38,7 +38,7 @@ local function CLIENT_OnWX78ScannerSpawned(inst)
 			inst._insight_scan_label = label
 
 			inst:ListenForEvent("insight_scan_progress_dirty", function(inst)
-				local context = GetPlayerContext(localPlayer)
+				local context = Insight.API.GetPlayerContext(localPlayer)
 				local val = inst.insight_scan_progress:value()
 
 				if not context.config["wx78_scanner_info"] or val < 0 then

--- a/scripts/screens/insightconfigurationscreen.lua
+++ b/scripts/screens/insightconfigurationscreen.lua
@@ -778,7 +778,7 @@ function InsightConfigurationScreen:PopulateKeybinds(tbl)
 
 	table.insert(tbl, {
 		name = "KEYBINDS",
-		label = GetPlayerContext(self.owner).lstr.keybinds.label, 
+		label = Insight.API.GetPlayerContext(self.owner).lstr.keybinds.label, 
 		options = {{description = "", data = 0}},
 		saved = 0,
 		default = 0,

--- a/scripts/services/playercontextmanager.lua
+++ b/scripts/services/playercontextmanager.lua
@@ -1,0 +1,164 @@
+--[[
+Copyright (C) 2020, 2021 penguin0616
+
+This file is part of Insight.
+
+The source code of this program is shared under the RECEX
+SHARED SOURCE LICENSE (version 1.0).
+The source code is shared for referrence and academic purposes
+with the hope that people can read and learn from it. This is not
+Free and Open Source software, and code is not redistributable
+without permission of the author. Read the RECEX SHARED
+SOURCE LICENSE for details
+The source codes does not come with any warranty including
+the implied warranty of merchandise.
+You should have received a copy of the RECEX SHARED SOURCE
+LICENSE in the form of a LICENSE file in the root of the source
+directory. If not, please refer to
+<https://raw.githubusercontent.com/Recex/Licenses/master/SharedSourceLicense/LICENSE.txt>
+]]
+
+--- This singleton services as the manager for player contexts. 
+--- On the server, it manages contexts for everyone.
+--- On the client, it manages context for the local player.
+--- @class PlayerContextManager
+--- @field private PlayerContexts table Player contexts managed by the manager.
+local PlayerContextManager = {
+	PlayerContexts = {}
+}
+
+local PlayerContext = import("objects/playercontext")
+
+--- Checks whether a player's context exists.
+--- @param player EntityScript
+--- @return bool
+function PlayerContextManager:HasContext(player)
+	if not (type(player) == "table" and type(player.is_a) == "function" and player:is_a(EntityScript)) then
+		argerror(1, "GetContext", "EntityScript", player)
+	end
+
+	if IS_DST and TheWorld.ismastersim then
+		-- i know we'll have it
+		context = self.PlayerContexts[player]
+	else
+		-- will be the only context
+		context = self.PlayerContexts[player]
+	end
+
+	return context ~= nil
+end
+
+--- Returns a copy of the player's PlayerContext
+--- @param player EntityScript
+--- @return PlayerContext
+function PlayerContextManager:GetContext(player)
+	if not (type(player) == "table" and type(player.is_a) == "function" and player:is_a(EntityScript)) then
+		argerror(1, "GetContext", "EntityScript", player)
+	end
+
+	if IS_DST and TheWorld.ismastersim then
+		-- i know we'll have it
+		context = self.PlayerContexts[player]
+	else
+		-- will be the only context
+		context = self.PlayerContexts[player]
+	end
+
+	if context then
+		return setmetatable({ FROM_INSPECTION=false }, { __index=context })
+	end
+end
+
+--- Returns all of the player contexts.
+--- @return table<PlayerContext>
+function PlayerContextManager:GetAllContexts()
+	return self.PlayerContexts
+end
+
+--- Removes the player's context
+--- @param player EntityScript Player entity.
+function PlayerContextManager:RemoveContext(player)
+	self.PlayerContexts[player] = nil
+end
+
+
+--- Creates a new instance of a player context.
+--- @param player EntityScript Player entity.
+--- @param configs table The sets of configuration options that the player currently has -- vanilla, external, and complex.
+--- @param etc table etc. I should have named this better :(
+--- @return PlayerContext @The created player context
+function PlayerContextManager:CreateContext(player, configs, etc)
+	local context = PlayerContext.new(player, configs, etc)
+
+	self.PlayerContexts[player] = context
+
+	return context
+end
+
+--- Updates a player's context if they already have one.
+--- @param player EntityScript Player entity.
+--- @param configs table The sets of configuration options that the player currently has -- vanilla, external, and complex.
+--- @param etc table etc. I should have named this better :(
+--- @return PlayerContext @The created player context
+function PlayerContextManager:UpdateContext(player, configs, etc)
+	if not self.PlayerContexts[player] then
+		mprint("Can't update missing player context.")
+		return
+	end
+
+	-- I don't quite remember why I made the old UpdatePlayerContext like that.
+	-- Will just rebuild it.
+	return self:CreateContext(player, data, etc)
+end
+
+--[[
+--- Updates a player's context if they already have one.
+---@param player EntityScript
+---@param data table
+function UpdatePlayerContext(player, data)
+	local context = player_contexts[player]
+	if not context then
+		mprint("Can't update missing player context.")
+		return
+	end
+
+	local oldLang = context.config["language"]
+	if data.configs then
+		if type(data.configs.vanilla) ~= "table" then
+			if IS_DST then TheNet:Kick(player.userid) return end
+			error("[Insight]: UpdatePlayerContext Config is invalid!")
+		end
+
+		if type(data.configs.external) ~= "table" then
+			if IS_DST then TheNet:Kick(player.userid) return end
+			error("[Insight]: UpdatePlayerContext external config is invalid!")
+		end
+
+		if type(data.configs.complex) ~= "table" then
+			if IS_DST then TheNet:Kick(player.userid) return end
+			error("[Insight]: UpdatePlayerContext complex config is invalid!")
+		end
+
+		ValidateComplexConfiguration(player, data.configs.complex)
+
+		context.config = setmetatable(data.configs.vanilla, CONTEXT_META)
+		context.external_config = setmetatable(data.configs.external, CONTEXT_META)
+		context.complex_config = setmetatable(data.configs.complex, CONTEXT_META)
+	end
+	data.configs = nil
+
+	for i,v in pairs(data) do
+		context[i] = v
+	end
+
+	local oldUsingIcons = context.usingIcons
+	context.usingIcons = context.config["info_style"] == "icon"
+
+	if oldLang ~= context.config["language"] or oldUsingIcons ~= context.usingIcons then
+		context.lstr = language(context.config, context.etc.locale)
+		context.etc.locale = context.config["language"]
+	end
+end
+]]
+
+return PlayerContextManager

--- a/scripts/services/playercontextmanager.lua
+++ b/scripts/services/playercontextmanager.lua
@@ -88,6 +88,7 @@ end
 --- @param etc table etc. I should have named this better :(
 --- @return PlayerContext @The created player context
 function PlayerContextManager:CreateContext(player, configs, etc)
+	mprint("Creating player context for", player)
 	local context = PlayerContext.new(player, configs, etc)
 
 	self.PlayerContexts[player] = context
@@ -101,6 +102,7 @@ end
 --- @param etc table etc. I should have named this better :(
 --- @return PlayerContext @The created player context
 function PlayerContextManager:UpdateContext(player, configs, etc)
+	mprint("Updating player context for", player)
 	if not self.PlayerContexts[player] then
 		mprint("Can't update missing player context.")
 		return

--- a/scripts/services/playercontextmanager.lua
+++ b/scripts/services/playercontextmanager.lua
@@ -108,7 +108,7 @@ function PlayerContextManager:UpdateContext(player, configs, etc)
 
 	-- I don't quite remember why I made the old UpdatePlayerContext like that.
 	-- Will just rebuild it.
-	return self:CreateContext(player, data, etc)
+	return self:CreateContext(player, configs, etc)
 end
 
 --[[

--- a/scripts/uichanges/mapscreen.lua
+++ b/scripts/uichanges/mapscreen.lua
@@ -38,7 +38,7 @@ local function OnMapScreenPostInit(self)
 	local text = root:AddChild(RichText(UIFONT, 24))
 	text:SetPosition(0, -12-6, 0)
 	if localPlayer and localPlayer.GetSeeableTilePercent then
-		local context = GetPlayerContext(localPlayer)
+		local context = Insight.API.GetPlayerContext(localPlayer)
 		if context.config["show_map_info"] then
 			local percent = localPlayer:GetSeeableTilePercent()
 			local color = MIN_EXPLORATION_COLOR:Lerp(MAX_EXPLORATION_COLOR, percent)

--- a/scripts/uichanges/pausescreen.lua
+++ b/scripts/uichanges/pausescreen.lua
@@ -30,7 +30,9 @@ local function PostButtons(screen, buttons)
 		text = "Insight Menu", 
 		cb = function() 
 			screen:unpause()
-			localPlayer.HUD.controls:ToggleInsightMenu()
+			if localPlayer then -- Shouldn't ever be nil, but you know how it is.
+				localPlayer.HUD.controls:ToggleInsightMenu()
+			end
 		end 
 	})
 

--- a/scripts/uichanges/playerstatusscreen.lua
+++ b/scripts/uichanges/playerstatusscreen.lua
@@ -25,7 +25,7 @@ local function UpdatePlayerListing(self)
 	local font_size = 16
 	local listing = self.widget
 
-	local context = localPlayer and GetPlayerContext(localPlayer)
+	local context = localPlayer and Insight.API.GetPlayerContext(localPlayer)
 
 	if not localPlayer or not context or not context.config["display_shared_stats"] then
 		listing.insight_text:SetString(nil)

--- a/scripts/uichanges/recipelookup.lua
+++ b/scripts/uichanges/recipelookup.lua
@@ -237,6 +237,12 @@ local function CraftingMenuDetails_PopulateRecipeDetailPanel(self, ...)
 	-- Yeah, yeah. No returning...
 	module.oldCraftingMenuDetails_PopulateRecipeDetailPanel(self, ...)
 
+	local context = localPlayer and Insight.API.GetPlayerContext(localPlayer)
+	if not context or not context.config["display_crafting_lookup_button"] then
+		--dprint("rejected, 1", self.recipe and self.recipe.product)
+		return
+	end
+
 	local data = ...
 	if not data then
 		return

--- a/scripts/uichanges/recipelookup.lua
+++ b/scripts/uichanges/recipelookup.lua
@@ -38,7 +38,7 @@ local WikiGGBaseURL = "https://dontstarve.wiki.gg/"
 local function GetBaseWikiURL()
 	local base = WikiGGBaseURL
 
-	local ctx = localPlayer and GetPlayerContext(localPlayer)
+	local ctx = localPlayer and Insight.API.GetPlayerContext(localPlayer)
 	if ctx and ctx.etc.locale ~= "en" then
 		if ctx.etc.locale == "zh" then
 			-- I'll leave this as Fandom for now.
@@ -120,7 +120,7 @@ function CookbookPageCrockPot_PopulateRecipeDetailPanel(self, data)
 	-- there's self.details_root, and this details_root, so its technically self.details_root.details_root even though that doesnt actually work
 	local details_root = module.oldCookbookPageCrockPot_PopulateRecipeDetailPanel(self, data)
 
-	local context = localPlayer and GetPlayerContext(localPlayer)
+	local context = localPlayer and Insight.API.GetPlayerContext(localPlayer)
 	if not context or not context.config["display_crafting_lookup_button"] then
 		--dprint("rejected, 1", self.recipe and self.recipe.product)
 		return details_root
@@ -158,7 +158,7 @@ end
 local function RecipePopup_Refresh(self)
 	--mprint"refresh"
 	module.oldRecipePopup_Refresh(self)
-	local context = localPlayer and GetPlayerContext(localPlayer)
+	local context = localPlayer and Insight.API.GetPlayerContext(localPlayer)
 	if not context or not context.config["display_crafting_lookup_button"] then
 		--dprint("rejected, 1", self.recipe and self.recipe.product)
 		return

--- a/scripts/uichanges/wxchargedisplay.lua
+++ b/scripts/uichanges/wxchargedisplay.lua
@@ -33,7 +33,7 @@ local statusAnnouncementsPresent = false
 --- Generates the hover text string. 
 ---@param plain boolean Whether formatting tags are included.
 local function GetChargeString(plain)
-	local context = GetPlayerContext(localPlayer)
+	local context = Insight.API.GetPlayerContext(localPlayer)
 	local info = localPlayer.replica.insight:GetInformation(localPlayer)
 
 	-- nil == unregistered, false == full charge, number == time till next charge

--- a/scripts/utility/eventer.lua
+++ b/scripts/utility/eventer.lua
@@ -71,9 +71,13 @@ function Event:AddListener(name, fn, weak)
 		if type(name) == "function" and fn == nil then
 			-- This was called with no name.
 			fn = name
-			name = "listener" .. GetTableSize(self.listeners) + 1
+			repeat
+				name = "listener" .. math.random(1, 0xFFFFFF)
+			until self.listeners[name] == nil -- Rare edge case where number was the same
 		elseif name == nil then
-			name = "listener" .. GetTableSize(self.listeners) + 1
+			repeat
+				name = "listener" .. math.random(1, 0xFFFFFF)
+			until self.listeners[name] == nil -- Rare edge case where number was the same
 		else
 			errorf("Adding an event listener requires a name, got '%s'", type(name))
 		end

--- a/scripts/widgets/insight_targetindicator.lua
+++ b/scripts/widgets/insight_targetindicator.lua
@@ -160,7 +160,7 @@ function InsightTargetIndicator:UpdateName()
 	end
 
 	if self.config_data.dismissable then
-		local ctx = self.owner and GetPlayerContext(self.owner) or nil
+		local ctx = self.owner and Insight.API.GetPlayerContext(self.owner) or nil
 		local lang = ctx and ctx.lstr or language.AssumeLanguageTable()
 		self.name = self.name .. "\n" .. string.format(lang.indicators.dismiss, TheInput:GetLocalizedControl(TheInput:GetControllerID(), CONTROL_SECONDARY))
 	end

--- a/scripts/widgets/itemdetail.lua
+++ b/scripts/widgets/itemdetail.lua
@@ -118,7 +118,7 @@ function ItemDetail:OnControl(control, down)
 			)
 
 			if describer then
-				local data = describer(special_data, GetPlayerContext(localPlayer), TheWorld)
+				local data = describer(special_data, Insight.API.GetPlayerContext(localPlayer), TheWorld)
 				if data and data.description then
 					-- Using self.componentName here so that the cooldown is unique per individual describe from a descriptor, not for the entire descriptor.
 					localPlayer.HUD._StatusAnnouncer:Announce(data.description, self.componentName) 


### PR DESCRIPTION
# v6.0.2 patch notes

## Changes / Additions

- Insight's mod size has been considerably reduced, so updates and downloads should be faster.
- Added server side flexibility for mob attack damage and harvestable information.

## Bugfixes

- Fixed a crash when using mods that break health regeneration.
- Fixed a crash when using mods that break perishables.
- Fixed a crash when using mods that introduce modified versions of the Tiger Shark.
- Fixed a crash when using mods that use non-standard weapon damage setups.
- Fixed a rare crash when hunts would fail in Shipwrecked-style mods.
- Fixed a crash when using mods that remove stages from the shadow portal.
- Fixed an extremely rare crash when attempting to interact with the Insight menu with no character.
- Fixed an issue where the recipe lookup button in the crafting menu wasn't respecting configurations.
- Fixed an extremely rare crash when setting up event listeners.
- Added some additional logic to try handling cases where mods tamper with vanilla action registration. If that still somehow isn't enough, Insight will just crash immediately stating as much instead of randomly during gameplay.

## Notes for Modders

- API use of GetPlayerContext has been standardized across Insight.
- Moved player contexts & player context management to their own files outside of modmain. If for some reason you were accessing them directly (you shouldn't!), you'll need to change that.